### PR TITLE
feat: add dynamic celestial events

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,9 @@ document.addEventListener('DOMContentLoaded', function(){
     towing:{base:25, perUnit:0.02},
     supernova:{minLife:4800,maxLife:9600,warnWindow:900,yield:[16,32],kick:[1.4,2.8],shockParticles:80},
     hazards:{nebulae:6},
+    comets:{spawnEvery:[600,1200],speed:[4,7],damage:30},
+    solarFlare:{min:800,max:1600,damage:15,stun:90,radius:260},
+    nebulaStar:{blue:0.00005,purple:0.00008,green:0.00003},
     ui:{starWarnRadius:900}
   };
 
@@ -235,18 +238,19 @@ document.addEventListener('DOMContentLoaded', function(){
         inv:CFG.ship.invuln, blink:0, justSpawned:true,
         lives:3, hull:CFG.ship.hullMax, hullMax:CFG.ship.hullMax, canShoot:true, cool:0,
         engine:1, hold:0, shield:0, gun:1, trail:[],
-        centerX:0, centerY:0, centered:false
+        centerX:0, centerY:0, centered:false, flare:0
       };
   }
   function makeAsteroid(x,y,r){ var n=irand(CFG.asteroid.verts[0],CFG.asteroid.verts[1]); var offs=Array.from({length:n},function(){return rand(1-CFG.asteroid.jag,1+CFG.asteroid.jag)}); var vel=rand(CFG.asteroid.speed[0],CFG.asteroid.speed[1]); var va=rand(0,Math.PI*2); return {x:x,y:y,r:r,vx:Math.cos(va)*vel,vy:Math.sin(va)*vel,a:rand(0,Math.PI*2),spin:rand(-.008,.008),offs:offs}; }
   function splitAst(a){ var res=[]; if(a.r>CFG.asteroid.sizes[2]+1){ var next=a.r===CFG.asteroid.sizes[0]?CFG.asteroid.sizes[1]:CFG.asteroid.sizes[2]; for(var i=0;i<2;i++){ var p=makeAsteroid(a.x+rand(-8,8),a.y+rand(-8,8),next); p.vx+=a.vx*.25; p.vy+=a.vy*.25; res.push(p); } } return res; }
   function makePlanet(i){ var types=["rocky","ocean","ice","lava","gas","industrial"]; var type=types[i % types.length]; var r=irand(28,80); var x,y,tries=0; do{ x=rand(200,WORLD.w-200); y=rand(200,WORLD.h-200); tries++; } while((Math.hypot(x-WORLD.w/2,y-WORLD.h/2)<360 || !farFromAll(x,y,state.blackholes,state.planets)) && tries<200); var names=["Eden","Kovax","Aria","Tarsis","Veld","Khepri","Nysa","Osiris","Ixia","Carina","Prax","Rhea"]; var p={ id:i,x:x,y:y,r:r,type:type,rot:rand(0,Math.PI*2),rotSpeed:rand(-0.0012,0.0012), hasRings:(Math.random()<0.25)&&r>40, name:names[i%names.length]+"-"+(100+i), stock:{fuel:irand(200,600),ammo:irand(50,150)}, prices:{fuel:2+rand(-.3,.4),ammo:5+rand(-1,1),repair:20}, offers:[] }; var tex=bakePlanetTexture(p); p.tex=tex.planet; p.ringsTex=tex.rings; return p; }
   function makeBlackHole(){ return {x:rand(180,WORLD.w-180),y:rand(180,WORLD.h-180),r:32}; }
-  function makeStar(){ var r=irand(36,88), x,y; do{ x=rand(200,WORLD.w-200); y=rand(200,WORLD.h-200);} while(!farFromAll(x,y,state.blackholes,state.planets) || !farFromStars(x,y,state.stars)); var life=irand(CFG.supernova.minLife, CFG.supernova.maxLife); return {x:x,y:y,r:r, life:life, unstableAt: life-CFG.supernova.warnWindow, phase:'stable', pulse:0, warned:false}; }
+  function makeStar(x,y){ var r=irand(36,88); if(x==null || y==null){ do{ x=rand(200,WORLD.w-200); y=rand(200,WORLD.h-200);} while(!farFromAll(x,y,state.blackholes,state.planets) || !farFromStars(x,y,state.stars)); } var life=irand(CFG.supernova.minLife, CFG.supernova.maxLife); return {x:x,y:y,r:r, life:life, unstableAt: life-CFG.supernova.warnWindow, phase:'stable', pulse:0, warned:false, flare:irand(CFG.solarFlare.min, CFG.solarFlare.max)}; }
   function makePirate(){ var side=irand(0,4); var m=80; var pos=[{x:-m,y:rand(0,WORLD.h)},{x:WORLD.w+m,y:rand(0,WORLD.h)},{x:rand(0,WORLD.w),y:-m},{x:rand(0,WORLD.w),y:WORLD.h+m}][side]; return {x:pos.x,y:pos.y,r:16,vx:0,vy:0,a:0,hp:7,cool:120,boardTimer:90}; }
   function makeGate(i){ var pad=260; var pts=[{x:pad,y:pad},{x:WORLD.w-pad,y:WORLD.h-pad},{x:WORLD.w-pad,y:pad},{x:pad,y:WORLD.h-pad}]; var pos=pts[i%pts.length]; return {id:i,x:pos.x,y:pos.y,r:28,link:(i%2===0)?i+1:i-1}; }
-  function makeNebula(){ var r=irand(260,420); var x=rand(120,WORLD.w-120), y=rand(120,WORLD.h-120); var c=document.createElement('canvas'); var dim=Math.ceil(r*2.6); c.width=c.height=dim; var g=c.getContext('2d'); g.translate(dim/2,dim/2); var hues=[[210,250],[270,310],[180,220]][irand(0,3)]; for(var i=0;i<irand(28,44);i++){ var a=rand(0,Math.PI*2), rr=rand(0,r*0.9); var xx=Math.cos(a)*rr, yy=Math.sin(a)*rr; var rad=rand(r*0.15,r*0.38); var hue=irand(hues[0],hues[1]); var grad=g.createRadialGradient(xx,yy,rad*0.2,xx,yy,rad); grad.addColorStop(0,'hsla('+hue+',70%,65%,.22)'); grad.addColorStop(1,'hsla('+hue+',70%,50%,0)'); g.fillStyle=grad; g.beginPath(); g.arc(xx,yy,rad,0,Math.PI*2); g.fill(); }
-    return {x:x,y:y,r:r,tex:c}; }
+  function makeComet(){ var edge=irand(0,4); var speed=rand(CFG.comets.speed[0],CFG.comets.speed[1]); var x,y,vx,vy; if(edge===0){ x=-40; y=rand(0,WORLD.h); vx=speed; vy=rand(-1,1); } else if(edge===1){ x=WORLD.w+40; y=rand(0,WORLD.h); vx=-speed; vy=rand(-1,1); } else if(edge===2){ x=rand(0,WORLD.w); y=-40; vx=rand(-1,1); vy=speed; } else { x=rand(0,WORLD.w); y=WORLD.h+40; vx=rand(-1,1); vy=-speed; } return {x:x,y:y,vx:vx,vy:vy,r:8,life:irand(600,1200)}; }
+  function makeNebula(x,y){ var r=irand(260,420); if(x==null || y==null){ x=rand(120,WORLD.w-120); y=rand(120,WORLD.h-120); } var c=document.createElement('canvas'); var dim=Math.ceil(r*2.6); c.width=c.height=dim; var g=c.getContext('2d'); g.translate(dim/2,dim/2); var palettes=[{range:[210,250],name:'blue',prob:CFG.nebulaStar.blue},{range:[270,310],name:'purple',prob:CFG.nebulaStar.purple},{range:[180,220],name:'green',prob:CFG.nebulaStar.green}]; var pal=palettes[irand(0,palettes.length)]; var density=rand(0.4,1); for(var i=0;i<irand(28,44);i++){ var a=rand(0,Math.PI*2), rr=rand(0,r*0.9); var xx=Math.cos(a)*rr, yy=Math.sin(a)*rr; var rad=rand(r*0.15,r*0.38); var hue=irand(pal.range[0],pal.range[1]); var grad=g.createRadialGradient(xx,yy,rad*0.2,xx,yy,rad); grad.addColorStop(0,'hsla('+hue+',70%,65%,.22)'); grad.addColorStop(1,'hsla('+hue+',70%,50%,0)'); g.fillStyle=grad; g.beginPath(); g.arc(xx,yy,rad,0,Math.PI*2); g.fill(); }
+    return {x:x,y:y,r:r,tex:c,color:pal.name,density:density,starProb:pal.prob*density}; }
 
   function farFromAll(x,y,blackholes,planets){ if(blackholes){ for(var i=0;i<blackholes.length;i++){ var h=blackholes[i]; if(Math.hypot(x-h.x,y-h.y) < h.r + CFG.safety.fromBH) return false; } } if(planets){ for(var j=0;j<planets.length;j++){ var p=planets[j]; if(Math.hypot(x-p.x,y-p.y) < p.r + CFG.safety.fromPlanet) return false; } } if(state && state.stars){ for(var k=0;k<state.stars.length;k++){ var s=state.stars[k]; if(Math.hypot(x-s.x,y-s.y) < s.r + CFG.safety.fromStar) return false; } } return true; }
   function farFromStars(x,y,stars){ if(!stars) return true; for(var i=0;i<stars.length;i++){ var s=stars[i]; if(Math.hypot(x-s.x,y-s.y) < s.r + CFG.safety.fromStar) return false; } return true; }
@@ -256,7 +260,8 @@ document.addEventListener('DOMContentLoaded', function(){
     state={ ship:newShip(), credits:CFG.economy.startCredits, fuel:CFG.economy.fuelStart, ammo:CFG.economy.ammoStart,
       cargo:0, cargoMax:CFG.economy.cargoMax, bullets:[], particles:[], asteroids:[], planets:[], blackholes:[],
       pirates:[], missions:[], score:0, gameOver:false, spawnTimer:900, reputation:0, tracked:null,
-      gates:[], fow:new Set(), docked:null, stars:[], towed:false, nebulae:[], discovered:new Set(), home:null };
+      gates:[], fow:new Set(), docked:null, stars:[], towed:false, nebulae:[], discovered:new Set(), home:null,
+      comets:[], cometTimer:irand(CFG.comets.spawnEvery[0],CFG.comets.spawnEvery[1]) };
     for(var i=0;i<CFG.planets;i++) state.planets.push(makePlanet(i));
     for(var j=0;j<CFG.blackholes;j++){ var bh; var tries=0; do{ bh=makeBlackHole(); tries++; } while(!farFromAll(bh.x,bh.y,state.blackholes,state.planets) && tries<200); state.blackholes.push(bh); }
     for(var s=0;s<CFG.stars;s++){ state.stars.push(makeStar()); }
@@ -293,7 +298,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function setHome(){ if(!state || !state.docked) return; state.home = state.docked; toast('Home set to '+state.home.name); renderDock(); }
 
   function keybinds(){
-    window.addEventListener('keydown',function(e){ if(!running||!state) return; if(e.repeat) return; var s=state.ship; switch(e.code){
+    window.addEventListener('keydown',function(e){ if(!running||!state) return; if(e.repeat) return; var s=state.ship; if(s.flare>0) return; switch(e.code){
       case 'ArrowLeft': case 'KeyA': s.turn=-1; break;
       case 'ArrowRight': case 'KeyD': s.turn=1; break;
       case 'ArrowUp': case 'KeyW': s.thrust=true; break;
@@ -303,7 +308,7 @@ document.addEventListener('DOMContentLoaded', function(){
       case 'ShiftLeft': case 'ShiftRight': hyperspace(); break;
       case 'KeyP': togglePause(); break;
     }});
-    window.addEventListener('keyup',function(e){ if(!running||!state) return; var s=state.ship; switch(e.code){
+    window.addEventListener('keyup',function(e){ if(!running||!state) return; var s=state.ship; if(s.flare>0) return; switch(e.code){
       case 'ArrowLeft': case 'KeyA': if(s.turn<0) s.turn=0; break;
       case 'ArrowRight': case 'KeyD': if(s.turn>0) s.turn=0; break;
       case 'ArrowUp': case 'KeyW': s.thrust=false; break;
@@ -352,7 +357,7 @@ document.addEventListener('DOMContentLoaded', function(){
   function renderMissionLog(){ if(!state){ ui.missionLogList.innerHTML='<div class="item">No active missions.</div>'; return; } var items=state.missions.map(function(m){ var dest=planetById(m.to); var from=planetById(m.from); var tracked=state.tracked===m.id; var left=Math.max(0,Math.floor(m.timeLeft)); return '<div class="item"><div><b>'+m.qty+' units</b> from <i>'+from.name+'</i> → <i>'+dest.name+'</i> <span class="badge">$'+m.reward+'</span> <span class="badge">'+left+'s</span></div><div><button class="btn" data-track="'+m.id+'">'+(tracked?'Untrack':'Track')+'</button></div></div>'; }).join('') || '<div class="item">No active missions. Dock and accept contracts.</div>'; ui.missionLogList.innerHTML=items; ui.missionLogList.querySelectorAll('[data-track]').forEach(function(b){ b.onclick=function(){ toggleTrack(b.getAttribute('data-track')); }; }); }
   function toggleTrack(id){ if(!state) return; state.tracked=(state.tracked===id?null:id); renderMissionLog(); }
 
-  function fire(){ if(!state) return; var s=state.ship; if(s.cool>0||state.bullets.length>=CFG.bullets.max||state.ammo<=0) return; s.cool=CFG.bullets.cool; state.ammo--; var tip={x:s.x+Math.cos(s.a)*s.r,y:s.y+Math.sin(s.a)*s.r}; state.bullets.push({x:tip.x,y:tip.y,vx:Math.cos(s.a)*CFG.bullets.speed+s.vx*.25,vy:Math.sin(s.a)*CFG.bullets.speed+s.vy*.25,life:CFG.bullets.life,r:2.4}); updateHUD(); }
+  function fire(){ if(!state) return; var s=state.ship; if(s.flare>0) return; if(s.cool>0||state.bullets.length>=CFG.bullets.max||state.ammo<=0) return; s.cool=CFG.bullets.cool; state.ammo--; var tip={x:s.x+Math.cos(s.a)*s.r,y:s.y+Math.sin(s.a)*s.r}; state.bullets.push({x:tip.x,y:tip.y,vx:Math.cos(s.a)*CFG.bullets.speed+s.vx*.25,vy:Math.sin(s.a)*CFG.bullets.speed+s.vy*.25,life:CFG.bullets.life,r:2.4}); updateHUD(); }
   function hyperspace(){ if(!state) return; var s=state.ship; for(var t=0;t<30;t++){ var x=rand(60,WORLD.w-60),y=rand(60,WORLD.h-60); if(farFromAll(x,y,state.blackholes,state.planets)){ s.x=x; s.y=y; s.vx=0; s.vy=0; s.inv=Math.max(s.inv,80); updateCamera(); return; } } s.x=WORLD.w/2; s.y=WORLD.h/2; s.vx=0; s.vy=0; s.inv=Math.max(s.inv,120); updateCamera(); }
   function useGate(){ if(!state) return; var g=nearbyGate(); if(!g) return; var link=state.gates.find(function(x){return x.id===g.link;}); if(!link) return; state.ship.x=link.x+40; state.ship.y=link.y+40; state.ship.vx*=0.2; state.ship.vy*=0.2; updateCamera(); toast('Warped via gate'); }
   function nearbyGate(){ if(!state) return null; for(var i=0;i<state.gates.length;i++){ var g=state.gates[i]; if(Math.hypot(g.x-state.ship.x,g.y-state.ship.y)<g.r+30) return g; } }
@@ -401,6 +406,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
   function update(dt){
     var s=state.ship; if(s.centered){ s.x=s.centerX; s.y=s.centerY; s.vx=0; s.vy=0; if(s.thrust) s.centered=false; }
+    if(s.flare>0){ s.flare-=1*dt; s.turn=0; s.thrust=false; }
     if(s.cool>0) s.cool--;
     s.a += s.turn*CFG.ship.turn*dt;
     if(s.thrust) s.justSpawned=false;
@@ -427,6 +433,11 @@ document.addEventListener('DOMContentLoaded', function(){
 
     state.bullets.forEach(function(b){ b.x+=b.vx*dt; b.y+=b.vy*dt; b.life-=1*dt; wrapEntity(b); });
     state.bullets=state.bullets.filter(function(b){ return b.life>0; });
+
+    state.cometTimer-=1*dt;
+    if(state.cometTimer<=0){ state.comets.push(makeComet()); state.cometTimer=irand(CFG.comets.spawnEvery[0],CFG.comets.spawnEvery[1]); }
+    state.comets.forEach(function(c){ c.x+=c.vx*dt; c.y+=c.vy*dt; c.life-=1*dt; });
+    state.comets=state.comets.filter(function(c){ return c.x>-100 && c.x<WORLD.w+100 && c.y>-100 && c.y<WORLD.h+100 && c.life>0; });
 
     // asteroids move
     for(var i=state.asteroids.length-1;i>=0;i--){ var a=state.asteroids[i]; a.x+=a.vx*dt; a.y+=a.vy*dt; a.a+=a.spin*dt; wrapEntity(a);
@@ -482,6 +493,8 @@ document.addEventListener('DOMContentLoaded', function(){
 
     for(var ee=state.bullets.length-1;ee>=0;ee--){ var EB=state.bullets[ee]; if(EB.enemy && Math.hypot(EB.x-state.ship.x,EB.y-state.ship.y)<state.ship.r+2){ state.bullets.splice(ee,1); damage(3); } }
 
+    for(var ci=state.comets.length-1; ci>=0; ci--){ var C=state.comets[ci]; if(state.ship.inv<=0 && Math.hypot(C.x-state.ship.x,C.y-state.ship.y) < C.r + state.ship.r*.8){ damage(CFG.comets.damage); explode(C.x,C.y,18); state.comets.splice(ci,1); }}
+
     state.missions.forEach(function(m){ m.timeLeft-=1*dt; }); state.missions=state.missions.filter(function(m){return m.timeLeft>0;});
     offerTimer-=1*dt; if(offerTimer<=0) refreshOffers(false);
 
@@ -489,16 +502,20 @@ document.addEventListener('DOMContentLoaded', function(){
     if(state.docked) tryDeliver();
     if(state.credits<=0 && state.ammo<=0 && state.fuel<=0){ return gameOver(); }
 
+    for(var ni2=state.nebulae.length-1; ni2>=0; ni2--){ var NB=state.nebulae[ni2]; if(Math.random()<NB.starProb*dt){ state.stars.push(makeStar(NB.x, NB.y)); state.nebulae.splice(ni2,1); toast('✨ A star is born!'); }}
+
     // Star lifecycle with proximity-based warnings
-    for(var sidx=state.stars.length-1; sidx>=0; sidx--){ var SS=state.stars[sidx]; SS.life -= 1*dt; var distToShip=Math.hypot(SS.x-state.ship.x, SS.y-state.ship.y);
+    for(var sidx=state.stars.length-1; sidx>=0; sidx--){ var SS=state.stars[sidx]; SS.life -= 1*dt; SS.flare -= 1*dt; var distToShip=Math.hypot(SS.x-state.ship.x, SS.y-state.ship.y);
       if(SS.phase==='stable' && SS.life<=SS.unstableAt){ SS.phase='unstable'; if(!SS.warned && distToShip < CFG.ui.starWarnRadius){ toast('⚠️ Stellar instability nearby!'); SS.warned=true; } }
       if(SS.phase==='unstable' && !SS.warned && distToShip < CFG.ui.starWarnRadius){ toast('⚠️ Stellar instability nearby!'); SS.warned=true; }
       if(SS.phase==='unstable'){ SS.pulse += 0.06*dt; }
+      if(SS.flare<=0){ solarFlare(SS); SS.flare=irand(CFG.solarFlare.min,CFG.solarFlare.max); }
       if(SS.life<=0){ supernova(sidx); }
     }
   }
 
-  function supernova(index){ var st=state.stars[index]; for(var i=0;i<CFG.supernova.shockParticles;i++){ var a=rand(0,Math.PI*2), sp=rand(1.0,3.6); state.particles.push({x:st.x,y:st.y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,life:rand(22,44),r:rand(1.4,2.6),h:rand(28,58)}); } var count=irand(CFG.supernova.yield[0], CFG.supernova.yield[1]); var baseAngle=rand(0,Math.PI*2); for(var k=0;k<count;k++){ var ang=baseAngle + (k/count)*Math.PI*2 + rand(-0.1,0.1); var off=rand(4, st.r*0.6); var ax=st.x + Math.cos(ang)*off; var ay=st.y + Math.sin(ang)*off; var size=pick(CFG.asteroid.sizes); var a=makeAsteroid(ax, ay, size); var kick=rand(CFG.supernova.kick[0], CFG.supernova.kick[1]); a.vx += Math.cos(ang)*kick; a.vy += Math.sin(ang)*kick; state.asteroids.push(a); } toast('💥 Supernova! New asteroid field detected.'); state.stars.splice(index,1); }
+  function supernova(index){ var st=state.stars[index]; for(var i=0;i<CFG.supernova.shockParticles;i++){ var a=rand(0,Math.PI*2), sp=rand(1.0,3.6); state.particles.push({x:st.x,y:st.y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,life:rand(22,44),r:rand(1.4,2.6),h:rand(28,58)}); } var count=irand(CFG.supernova.yield[0], CFG.supernova.yield[1]); var baseAngle=rand(0,Math.PI*2); for(var k=0;k<count;k++){ var ang=baseAngle + (k/count)*Math.PI*2 + rand(-0.1,0.1); var off=rand(4, st.r*0.6); var ax=st.x + Math.cos(ang)*off; var ay=st.y + Math.sin(ang)*off; var size=pick(CFG.asteroid.sizes); var a=makeAsteroid(ax, ay, size); var kick=rand(CFG.supernova.kick[0], CFG.supernova.kick[1]); a.vx += Math.cos(ang)*kick; a.vy += Math.sin(ang)*kick; state.asteroids.push(a); } state.nebulae.push(makeNebula(st.x, st.y)); toast('💥 Supernova! New asteroid field detected.'); state.stars.splice(index,1); }
+  function solarFlare(st){ for(var i=0;i<20;i++){ var a=rand(0,Math.PI*2), sp=rand(1,3); state.particles.push({x:st.x,y:st.y,vx:Math.cos(a)*sp,vy:Math.sin(a)*sp,life:rand(18,36),r:rand(1,2),h:rand(28,58)}); } var d=Math.hypot(state.ship.x-st.x,state.ship.y-st.y); if(d<CFG.solarFlare.radius){ damage(CFG.solarFlare.damage); state.ship.flare=CFG.solarFlare.stun; } toast('☀️ Solar flare!'); }
 
   function draw(){
     ctx.clearRect(0,0,W,H);
@@ -530,6 +547,9 @@ document.addEventListener('DOMContentLoaded', function(){
     // asteroids
     state.asteroids.forEach(function(a){ ctx.save(); ctx.translate(a.x,a.y); ctx.rotate(a.a); var fill=ctx.createLinearGradient(-a.r,-a.r,a.r,a.r); fill.addColorStop(0,'#1e2636'); fill.addColorStop(1,'#2b354a'); ctx.fillStyle=fill; ctx.strokeStyle='#aab6c8'; ctx.lineWidth=2; ctx.beginPath(); for(var i=0;i<a.offs.length;i++){ var ang=(Math.PI*2)*(i/a.offs.length); var r=a.r*a.offs[i]; var x=Math.cos(ang)*r, y=Math.sin(ang)*r; if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);} ctx.closePath(); ctx.fill(); ctx.stroke(); ctx.restore(); });
 
+    // comets
+    state.comets.forEach(function(c){ ctx.save(); ctx.translate(c.x,c.y); ctx.fillStyle='#fff'; ctx.beginPath(); ctx.arc(0,0,c.r,0,Math.PI*2); ctx.fill(); ctx.restore(); });
+
     // pirates
     state.pirates.forEach(function(p){ ctx.save(); ctx.translate(p.x,p.y); ctx.rotate(Math.atan2(state.ship.y-p.y,state.ship.x-p.x)); ctx.strokeStyle='#ffb3b3'; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(p.r,0); ctx.lineTo(-p.r*.6,-p.r*.6); ctx.lineTo(-p.r*.3,0); ctx.lineTo(-p.r*.6,p.r*.6); ctx.closePath(); ctx.stroke(); ctx.restore(); });
 
@@ -553,7 +573,7 @@ document.addEventListener('DOMContentLoaded', function(){
     // minimap & fog
     mctx.clearRect(0,0,180,180); mctx.strokeStyle='rgba(255,255,255,.15)'; mctx.strokeRect(0,0,180,180); var sx=180/WORLD.w, sy=180/WORLD.h;
     function drawMini(x,y,color,sz){ mctx.fillStyle=color; sz=sz||3; mctx.fillRect(x*sx- sz/2, y*sy- sz/2, sz, sz); }
-    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); if(!state.inNebula) drawMini(state.ship.x,state.ship.y,'#9cf',4); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
+    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); state.comets.forEach(function(c){ drawMini(c.x,c.y,'#fff',3); }); if(!state.inNebula) drawMini(state.ship.x,state.ship.y,'#9cf',4); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
     minimapFog(sx,sy);
     mctx.strokeStyle='rgba(255,255,255,.5)'; mctx.strokeRect(cam.x*sx, cam.y*sy, W*sx, H*sy);
   }


### PR DESCRIPTION
## Summary
- introduce fast-moving comets that spawn unpredictably and deal heavy damage on impact
- allow supernovae to leave behind nebulas that can later collapse into new stars
- add solar flares that damage and temporarily disable ship controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c45a2c68832f84de5f43f3798012