### PR TITLE
Improve stellar lifecycle and add rival haulers

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,11 +269,12 @@ document.addEventListener('DOMContentLoaded', function(){
       do{ x=rand(200,WORLD.w-200); y=rand(200,WORLD.h-200);} while(!farFromAll(x,y,state.blackholes,state.planets) || !farFromStars(x,y,state.stars));
     }
     var life=irand(CFG.supernova.minLife, CFG.supernova.maxLife);
-    var noise=document.createElement('canvas'); noise.width=noise.height=r*2; var ng=noise.getContext('2d'); ng.translate(r,r);
-    for(var i=0;i<80;i++){ var a=rand(0,Math.PI*2), rr=rand(0,r); ng.fillStyle='rgba(255,255,255,'+rand(0.05,0.15)+')'; ng.beginPath(); ng.arc(Math.cos(a)*rr,Math.sin(a)*rr,rand(0.5,1.5),0,Math.PI*2); ng.fill(); }
-    return {x:x,y:y,baseR:r,r:r, life:life, maxLife:life, hue:210, unstableAt: life-CFG.supernova.warnWindow, phase:'stable', pulse:0, warned:false, flare:irand(CFG.solarFlare.min, CFG.solarFlare.max), noise:noise};
+    var tex=bakePlanetTexture({r:r,type:'star'}).planet;
+    return {x:x,y:y,baseR:r,r:r, life:life, maxLife:life, hue:210, unstableAt: life-CFG.supernova.warnWindow, phase:'stable', pulse:0, warned:false, flare:irand(CFG.solarFlare.min, CFG.solarFlare.max), tex:tex, form:1};
   }
   function makePirate(){ var side=irand(0,4); var m=80; var pos=[{x:-m,y:rand(0,WORLD.h)},{x:WORLD.w+m,y:rand(0,WORLD.h)},{x:rand(0,WORLD.w),y:-m},{x:rand(0,WORLD.w),y:WORLD.h+m}][side]; return {x:pos.x,y:pos.y,r:16,vx:0,vy:0,a:0,hp:7,cool:120,boardTimer:90}; }
+  function makeHauler(of){ var from=planetById(of.from); return {x:from.x,y:from.y,vx:0,vy:0,r:14,hp:10,mission:of,agro:false,cool:120}; }
+  function spawnHauler(of){ state.haulers.push(makeHauler(of)); toast('📦 Rival hauler accepted a contract'); }
   function makeGate(i){ var pad=260; var pts=[{x:pad,y:pad},{x:WORLD.w-pad,y:WORLD.h-pad},{x:WORLD.w-pad,y:pad},{x:pad,y:WORLD.h-pad}]; var pos=pts[i%pts.length]; return {id:i,x:pos.x,y:pos.y,r:28,link:(i%2===0)?i+1:i-1}; }
   function makeComet(){
     var edge=irand(0,4); var speed=rand(CFG.comets.speed[0],CFG.comets.speed[1]); var x,y,vx,vy;
@@ -286,7 +287,7 @@ document.addEventListener('DOMContentLoaded', function(){
     return {x:x,y:y,vx:vx,vy:vy,r:8,a:rand(0,Math.PI*2),spin:rand(-0.02,0.02),offs:offs,life:irand(600,1200),trail:[],layer:Math.random(),tex:tex};
   }
   function makeNebula(x,y){ var r=irand(260,420); if(x==null || y==null){ x=rand(120,WORLD.w-120); y=rand(120,WORLD.h-120); } var c=document.createElement('canvas'); var dim=Math.ceil(r*2.6); c.width=c.height=dim; var g=c.getContext('2d'); g.translate(dim/2,dim/2); var palettes=[{range:[210,250],name:'blue',prob:CFG.nebulaStar.blue},{range:[270,310],name:'purple',prob:CFG.nebulaStar.purple},{range:[180,220],name:'green',prob:CFG.nebulaStar.green}]; var pal=palettes[irand(0,palettes.length)]; var density=rand(0.4,1); for(var i=0;i<irand(28,44);i++){ var a=rand(0,Math.PI*2), rr=rand(0,r*0.9); var xx=Math.cos(a)*rr, yy=Math.sin(a)*rr; var rad=rand(r*0.15,r*0.38); var hue=irand(pal.range[0],pal.range[1]); var grad=g.createRadialGradient(xx,yy,rad*0.2,xx,yy,rad); grad.addColorStop(0,'hsla('+hue+',70%,65%,.22)'); grad.addColorStop(1,'hsla('+hue+',70%,50%,0)'); g.fillStyle=grad; g.beginPath(); g.arc(xx,yy,rad,0,Math.PI*2); g.fill(); }
-    return {x:x,y:y,r:r,tex:c,color:pal.name,density:density,starProb:pal.prob*density,age:0,birthTime:irand(4800,9600),layer:Math.random(),alpha:0.2}; }
+    return {x:x,y:y,r:r,tex:c,color:pal.name,density:density,starProb:pal.prob*density,age:0,birthTime:irand(4800,9600),layer:Math.random(),alpha:0.2,vx:rand(-0.05,0.05),vy:rand(-0.05,0.05),stage:'nebula'}; }
   function makeGalaxy(){ var r=irand(12,24); var c=document.createElement('canvas'); c.width=c.height=r*4; var g=c.getContext('2d'); g.translate(c.width/2,c.height/2); var arms=irand(3,5); for(var a=0;a<arms;a++){ g.save(); g.rotate((Math.PI*2)*(a/arms)); var grad=g.createLinearGradient(0,0,r*2,0); grad.addColorStop(0,'rgba(255,255,255,0.8)'); grad.addColorStop(1,'rgba(255,255,255,0)'); g.strokeStyle=grad; g.lineWidth=2; g.beginPath(); g.moveTo(0,0); g.lineTo(r*2,0); g.stroke(); g.restore(); } g.fillStyle='rgba(255,255,255,0.8)'; g.beginPath(); g.arc(0,0,r*0.6,0,Math.PI*2); g.fill(); return {x:rand(0,WORLD.w),y:rand(0,WORLD.h),tex:c}; }
 
   function farFromAll(x,y,blackholes,planets){ if(blackholes){ for(var i=0;i<blackholes.length;i++){ var h=blackholes[i]; if(Math.hypot(x-h.x,y-h.y) < h.r + CFG.safety.fromBH) return false; } } if(planets){ for(var j=0;j<planets.length;j++){ var p=planets[j]; if(Math.hypot(x-p.x,y-p.y) < p.r + CFG.safety.fromPlanet) return false; } } if(state && state.stars){ for(var k=0;k<state.stars.length;k++){ var s=state.stars[k]; if(Math.hypot(x-s.x,y-s.y) < s.r + CFG.safety.fromStar) return false; } } return true; }
@@ -298,7 +299,7 @@ document.addEventListener('DOMContentLoaded', function(){
       cargo:0, cargoMax:CFG.economy.cargoMax, bullets:[], particles:[], asteroids:[], planets:[], blackholes:[],
       pirates:[], missions:[], score:0, gameOver:false, spawnTimer:CFG.pirates.spawnEvery, reputation:0, tracked:null,
       gates:[], fow:new Set(), docked:null, stars:[], towed:false, nebulae:[], discovered:new Set(), home:null,
-      comets:[], cometTimer:irand(CFG.comets.spawnEvery[0],CFG.comets.spawnEvery[1]), galaxies:[], flashes:[] };
+      comets:[], cometTimer:irand(CFG.comets.spawnEvery[0],CFG.comets.spawnEvery[1]), galaxies:[], flashes:[], haulers:[] };
     for(var i=0;i<CFG.planets;i++) state.planets.push(makePlanet(i));
     for(var j=0;j<CFG.blackholes;j++){ var bh; var tries=0; do{ bh=makeBlackHole(); tries++; } while(!farFromAll(bh.x,bh.y,state.blackholes,state.planets) && tries<200); state.blackholes.push(bh); }
     for(var s=0;s<CFG.stars;s++){ state.stars.push(makeStar()); }
@@ -503,7 +504,8 @@ document.addEventListener('DOMContentLoaded', function(){
     // pirates spawn & steer with avoidance
     state.spawnTimer-=1*dt; if(state.spawnTimer<=0){ state.pirates.push(makePirate()); state.spawnTimer=CFG.pirates.spawnEvery; }
     state.pirates.forEach(function(p){
-      var dx=state.ship.x-p.x, dy=state.ship.y-p.y; var d=Math.hypot(dx,dy);
+      var target=state.ship, dx=target.x-p.x, dy=target.y-p.y, d=Math.hypot(dx,dy);
+      state.haulers.forEach(function(h){ var dh=Math.hypot(h.x-p.x,h.y-p.y); if(dh<d){ target=h; dx=h.x-p.x; dy=h.y-p.y; d=dh; }});
       // basic chase
       if(d<380){ p.vx+=(dx/d)*.045*dt; p.vy+=(dy/d)*.045*dt; }
       // asteroid avoidance
@@ -513,10 +515,12 @@ document.addEventListener('DOMContentLoaded', function(){
       // fire
       p.cool-=1*dt; if(p.cool<=0 && d<380){ var a=Math.atan2(dy,dx); state.bullets.push({x:p.x+Math.cos(a)*p.r,y:p.y+Math.sin(a)*p.r,vx:Math.cos(a)*6.5,vy:Math.sin(a)*6.5,life:120,r:2.2,enemy:true}); p.cool=120; }
       // boarding
-      if(state.ship.inv<=0 && d<22){ p.boardTimer-=1*dt; if(p.boardTimer<=0){ pirateSteal(p); p.boardTimer=180; } } else { p.boardTimer=90; }
+      if(target===state.ship && state.ship.inv<=0 && d<22){ p.boardTimer-=1*dt; if(p.boardTimer<=0){ pirateSteal(p); p.boardTimer=180; } } else { p.boardTimer=90; }
       // movement
       p.x+=p.vx*dt; p.y+=p.vy*dt; wrapEntity(p);
     });
+
+    for(var hi=state.haulers.length-1; hi>=0; hi--){ var H=state.haulers[hi]; var dest=planetById(H.mission.to); var dx=dest.x-H.x, dy=dest.y-H.y; var d=Math.hypot(dx,dy); if(d<dest.r+8){ state.haulers.splice(hi,1); continue; } H.vx+=(dx/d)*0.03*dt; H.vy+=(dy/d)*0.03*dt; var spd=Math.hypot(H.vx,H.vy); if(spd>2){ H.vx=(H.vx/spd)*2; H.vy=(H.vy/spd)*2; } H.x+=H.vx*dt; H.y+=H.vy*dt; wrapEntity(H); if(H.agro){ H.cool-=1*dt; var dxp=state.ship.x-H.x, dyp=state.ship.y-H.y; var dp=Math.hypot(dxp,dyp); if(H.cool<=0 && dp<380){ var aa=Math.atan2(dyp,dxp); state.bullets.push({x:H.x+Math.cos(aa)*H.r,y:H.y+Math.sin(aa)*H.r,vx:Math.cos(aa)*6,vy:Math.sin(aa)*6,life:120,r:2.2,enemy:true}); H.cool=120; } }}
 
     // pirate vs asteroid collision (damage & split)
     for(var pi3=state.pirates.length-1;pi3>=0;pi3--){ var PP=state.pirates[pi3]; for(var ai2=state.asteroids.length-1;ai2>=0;ai2--){ var AA=state.asteroids[ai2]; if(Math.hypot(PP.x-AA.x,PP.y-AA.y) < PP.r+AA.r){
@@ -531,7 +535,7 @@ document.addEventListener('DOMContentLoaded', function(){
     }
 
     // black hole gravity — affects ship, asteroids, pirates, bullets
-    state.blackholes.forEach(function(h){ var soft=160; var maxPull=.45; var ents=[state.ship].concat(state.asteroids,state.pirates,state.bullets); ents.forEach(function(e){ var dx=h.x-e.x, dy=h.y-e.y; var d=Math.hypot(dx,dy); if(d<1) return; var pull=Math.min(1600/((d+soft)*(d+soft)), maxPull); e.vx+=(dx/d)*pull*dt; e.vy+=(dy/d)*pull*dt; if(d<h.r+10 && e!==state.ship){ if(e.r){ explode(e.x,e.y,10); } } }); });
+    state.blackholes.forEach(function(h){ var soft=160; var maxPull=.45; var ents=[state.ship].concat(state.asteroids,state.pirates,state.bullets,state.haulers); ents.forEach(function(e){ var dx=h.x-e.x, dy=h.y-e.y; var d=Math.hypot(dx,dy); if(d<1) return; var pull=Math.min(1600/((d+soft)*(d+soft)), maxPull); e.vx+=(dx/d)*pull*dt; e.vy+=(dy/d)*pull*dt; if(d<h.r+10 && e!==state.ship){ if(e.r){ explode(e.x,e.y,10); } } }); });
     if(s.centered){ s.x=s.centerX; s.y=s.centerY; s.vx=0; s.vy=0; }
 
     // stars: instant ship death
@@ -544,21 +548,27 @@ document.addEventListener('DOMContentLoaded', function(){
     for(var ai=state.asteroids.length-1;ai>=0;ai--){ var AA=state.asteroids[ai]; var hit=false; for(var bj=state.bullets.length-1;bj>=0;bj--){ var b=state.bullets[bj]; if(b.enemy) continue; if(Math.hypot(AA.x-b.x,AA.y-b.y)<AA.r){ state.bullets.splice(bj,1); state.asteroids.splice(ai,1); explode(AA.x,AA.y,12); state.credits+=10; var pcs=splitAst(AA); state.asteroids.push.apply(state.asteroids,pcs); updateHUD(); hit=true; break; } } if(hit) continue; if(AA.layer>=PLANET_LAYER && state.ship.inv<=0 && Math.hypot(AA.x-state.ship.x,AA.y-state.ship.y)<AA.r+state.ship.r*.8){ var dmg = AA.r>=CFG.asteroid.sizes[0]?15:(AA.r>=CFG.asteroid.sizes[1]?10:5); damage(dmg); } }
     for(var pk=state.pirates.length-1;pk>=0;pk--){ var P=state.pirates[pk]; for(var bj2=state.bullets.length-1;bj2>=0;bj2--){ var bb=state.bullets[bj2]; if(bb.enemy) continue; if(Math.hypot(P.x-bb.x,P.y-bb.y)<P.r+3){ state.bullets.splice(bj2,1); P.hp-=6; explode(P.x,P.y,8); if(P.hp<=0){ state.pirates.splice(pk,1); state.credits+=40; updateHUD(); } break; } } if(state.ship.inv<=0 && Math.hypot(P.x-state.ship.x,P.y-state.ship.y)<P.r+state.ship.r*.8){ damage(12); } }
 
+    for(var hk=state.haulers.length-1;hk>=0;hk--){ var HH=state.haulers[hk]; for(var bj3=state.bullets.length-1;bj3>=0;bj3--){ var b2=state.bullets[bj3]; if(Math.hypot(HH.x-b2.x,HH.y-b2.y)<HH.r+3){ state.bullets.splice(bj3,1); HH.hp-=6; if(!b2.enemy) HH.agro=true; if(HH.hp<=0){ state.haulers.splice(hk,1); } break; } } if(Math.hypot(HH.x-state.ship.x,HH.y-state.ship.y)<HH.r+state.ship.r*.8){ if(state.ship.inv<=0){ damage(8); HH.agro=true; } } }
+
     for(var ee=state.bullets.length-1;ee>=0;ee--){ var EB=state.bullets[ee]; if(EB.enemy && Math.hypot(EB.x-state.ship.x,EB.y-state.ship.y)<state.ship.r+2){ state.bullets.splice(ee,1); damage(3); } }
 
     for(var ci=state.comets.length-1; ci>=0; ci--){ var C=state.comets[ci]; if(C.layer>=PLANET_LAYER && state.ship.inv<=0 && Math.hypot(C.x-state.ship.x,C.y-state.ship.y) < C.r + state.ship.r*.8){ damage(CFG.comets.damage); explode(C.x,C.y,18); state.comets.splice(ci,1); }}
 
-    state.missions.forEach(function(m){ m.timeLeft-=1*dt; }); state.missions=state.missions.filter(function(m){return m.timeLeft>0;});
+    state.planets.forEach(function(pl){ for(var oi=pl.offers.length-1; oi>=0; oi--){ var of=pl.offers[oi]; of.timeLeft-=1*dt; if(of.timeLeft<=0){ spawnHauler(of); pl.offers.splice(oi,1); } } });
+    state.missions.forEach(function(m){ m.timeLeft-=1*dt; });
+    var expired=[];
+    state.missions=state.missions.filter(function(m){ if(m.timeLeft>0) return true; expired.push(m); return false; });
+    if(expired.length){ expired.forEach(function(m){ state.cargo=Math.max(0,state.cargo-m.qty); }); if(state.tracked && !state.missions.some(function(m){return m.id===state.tracked;})) state.tracked=null; updateHUD(); }
     offerTimer-=1*dt; if(offerTimer<=0) refreshOffers(false);
 
     checkFuelTow();
     if(state.docked) tryDeliver();
     if(state.credits<=0 && state.ammo<=0 && state.fuel<=0){ return gameOver(); }
 
-    for(var ni2=state.nebulae.length-1; ni2>=0; ni2--){ var NB=state.nebulae[ni2]; NB.age+=1*dt; NB.alpha=0.2+0.6*(NB.age/NB.birthTime); if(NB.age>=NB.birthTime){ state.stars.push(makeStar(NB.x, NB.y)); state.nebulae.splice(ni2,1); toast('✨ A star is born!'); }}
+    for(var ni2=state.nebulae.length-1; ni2>=0; ni2--){ var NB=state.nebulae[ni2]; NB.age+=1*dt; NB.x+=NB.vx*dt; NB.y+=NB.vy*dt; wrapEntity(NB); if(NB.stage==='fading'){ NB.alpha=Math.max(0,NB.alpha-0.002*dt); if(NB.alpha<=0){ state.nebulae.splice(ni2,1); } continue; } NB.alpha=0.2+0.6*(NB.age/NB.birthTime); if(NB.age>=NB.birthTime){ var st=makeStar(NB.x, NB.y); st.form=0; state.stars.push(st); NB.stage='fading'; toast('✨ A star is born!'); }}
 
     // Star lifecycle with proximity-based warnings
-    for(var sidx=state.stars.length-1; sidx>=0; sidx--){ var SS=state.stars[sidx]; SS.life -= 1*dt; SS.flare -= 1*dt; var age=1-SS.life/SS.maxLife; SS.hue=210-age*210; SS.r=SS.baseR*(1+age*0.4); var distToShip=Math.hypot(SS.x-state.ship.x, SS.y-state.ship.y);
+    for(var sidx=state.stars.length-1; sidx>=0; sidx--){ var SS=state.stars[sidx]; SS.life -= 1*dt; SS.flare -= 1*dt; if(SS.form<1) SS.form=Math.min(1,SS.form+0.002*dt); var age=1-SS.life/SS.maxLife; SS.hue=210-age*210; SS.r=SS.baseR*(1+age*0.4)*SS.form; var distToShip=Math.hypot(SS.x-state.ship.x, SS.y-state.ship.y);
       if(SS.phase==='stable' && SS.life<=SS.unstableAt){ SS.phase='unstable'; if(!SS.warned && distToShip < CFG.ui.starWarnRadius){ toast('⚠️ Stellar instability nearby!'); SS.warned=true; } }
       if(SS.phase==='unstable' && !SS.warned && distToShip < CFG.ui.starWarnRadius){ toast('⚠️ Stellar instability nearby!'); SS.warned=true; }
       if(SS.phase==='unstable'){ SS.pulse += 0.06*dt; }
@@ -601,8 +611,8 @@ document.addEventListener('DOMContentLoaded', function(){
     // black holes
     state.blackholes.forEach(function(h){ ctx.save(); ctx.translate(h.x,h.y); var grd=ctx.createRadialGradient(0,0,4,0,0,h.r); grd.addColorStop(0,'#111'); grd.addColorStop(1,'#000'); ctx.fillStyle=grd; ctx.beginPath(); ctx.arc(0,0,h.r,0,Math.PI*2); ctx.fill(); ctx.strokeStyle='rgba(109,184,242,.35)'; ctx.beginPath(); ctx.arc(0,0,h.r+10,0,Math.PI*2); ctx.stroke(); ctx.restore(); });
 
-    // stars (core + unstable telegraph)
-    state.stars.forEach(function(st){ ctx.save(); ctx.translate(st.x, st.y); var g=ctx.createRadialGradient(0,0,2,0,0,st.r); g.addColorStop(0,'hsl('+st.hue+',80%,90%)'); g.addColorStop(0.4,'hsl('+st.hue+',80%,60%)'); g.addColorStop(1,'hsla('+st.hue+',80%,40%,0.2)'); ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,st.r,0,Math.PI*2); ctx.fill(); ctx.globalAlpha=0.25; ctx.drawImage(st.noise,-st.noise.width/2,-st.noise.height/2); ctx.globalAlpha=1; if(st.phase==='unstable'){ var pulse=(Math.sin(st.pulse)+1)*0.5; ctx.globalAlpha = 0.35 + 0.35*pulse; ctx.strokeStyle='rgba(255,220,120,0.8)'; ctx.lineWidth=2 + 3*pulse; ctx.beginPath(); ctx.arc(0,0, st.r + 10 + 6*pulse, 0, Math.PI*2); ctx.stroke(); ctx.globalAlpha=1; } ctx.restore(); });
+    // stars (textured core + unstable telegraph)
+    state.stars.forEach(function(st){ ctx.save(); ctx.translate(st.x, st.y); ctx.drawImage(st.tex,-st.tex.width/2,-st.tex.height/2); var g=ctx.createRadialGradient(0,0,2,0,0,st.r); g.addColorStop(0,'hsl('+st.hue+',80%,90%)'); g.addColorStop(0.4,'hsl('+st.hue+',80%,60%)'); g.addColorStop(1,'hsla('+st.hue+',80%,40%,0.2)'); ctx.globalCompositeOperation='lighter'; ctx.fillStyle=g; ctx.beginPath(); ctx.arc(0,0,st.r,0,Math.PI*2); ctx.fill(); ctx.globalCompositeOperation='source-over'; if(st.phase==='unstable'){ var pulse=(Math.sin(st.pulse)+1)*0.5; ctx.globalAlpha = 0.35 + 0.35*pulse; ctx.strokeStyle='rgba(255,220,120,0.8)'; ctx.lineWidth=2 + 3*pulse; ctx.beginPath(); ctx.arc(0,0, st.r + 10 + 6*pulse, 0, Math.PI*2); ctx.stroke(); ctx.globalAlpha=1; } ctx.restore(); });
     state.gates.forEach(function(g){ ctx.save(); ctx.strokeStyle='#9bf'; ctx.lineWidth=3; ctx.beginPath(); ctx.arc(g.x,g.y,g.r,0,Math.PI*2); ctx.stroke(); ctx.restore(); });
 
     // particles
@@ -612,6 +622,9 @@ document.addEventListener('DOMContentLoaded', function(){
     state.nebulae.filter(function(n){return n.layer>=PLANET_LAYER;}).forEach(function(n){ ctx.save(); ctx.globalAlpha=n.alpha; ctx.drawImage(n.tex, n.x - n.tex.width/2, n.y - n.tex.height/2); ctx.restore(); });
     state.asteroids.filter(function(a){return a.layer>=PLANET_LAYER;}).forEach(function(a){ ctx.save(); ctx.translate(a.x,a.y); ctx.rotate(a.a); ctx.drawImage(a.tex,-a.tex.width/2,-a.tex.height/2); ctx.restore(); });
     state.comets.filter(function(c){return c.layer>=PLANET_LAYER;}).forEach(function(c){ ctx.save(); ctx.translate(c.x,c.y); ctx.rotate(c.a); ctx.beginPath(); for(var i=0;i<c.offs.length;i++){ var ang=(Math.PI*2)*(i/c.offs.length); var rr=c.r*c.offs[i]; var xx=Math.cos(ang)*rr, yy=Math.sin(ang)*rr; if(i===0) ctx.moveTo(xx,yy); else ctx.lineTo(xx,yy);} ctx.closePath(); ctx.clip(); ctx.drawImage(c.tex,-c.tex.width/2,-c.tex.height/2); ctx.restore(); ctx.save(); c.trail.forEach(function(t){ ctx.globalAlpha=t.life/40; ctx.fillStyle='#fff'; ctx.fillRect(t.x-1,t.y-1,2,2); }); ctx.restore(); });
+
+    // haulers
+    state.haulers.forEach(function(h){ ctx.save(); ctx.translate(h.x,h.y); ctx.rotate(Math.atan2(h.vy,h.vx||1)); ctx.strokeStyle='#9fc'; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(h.r,0); ctx.lineTo(-h.r*.6,-h.r*.6); ctx.lineTo(-h.r*.3,0); ctx.lineTo(-h.r*.6,h.r*.6); ctx.closePath(); ctx.stroke(); ctx.restore(); });
 
     // pirates
     state.pirates.forEach(function(p){ ctx.save(); ctx.translate(p.x,p.y); ctx.rotate(Math.atan2(state.ship.y-p.y,state.ship.x-p.x)); ctx.strokeStyle='#ffb3b3'; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(p.r,0); ctx.lineTo(-p.r*.6,-p.r*.6); ctx.lineTo(-p.r*.3,0); ctx.lineTo(-p.r*.6,p.r*.6); ctx.closePath(); ctx.stroke(); ctx.restore(); });
@@ -636,7 +649,7 @@ document.addEventListener('DOMContentLoaded', function(){
     // minimap & fog
     mctx.clearRect(0,0,180,180); mctx.strokeStyle='rgba(255,255,255,.15)'; mctx.strokeRect(0,0,180,180); var sx=180/WORLD.w, sy=180/WORLD.h;
     function drawMini(x,y,color,sz){ mctx.fillStyle=color; sz=sz||3; mctx.fillRect(x*sx- sz/2, y*sy- sz/2, sz, sz); }
-    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); state.comets.forEach(function(c){ drawMini(c.x,c.y,'#fff',3); }); if(!state.inNebula) drawMini(state.ship.x,state.ship.y,'#9cf',4); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
+    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); state.haulers.forEach(function(h){ drawMini(h.x,h.y,'#9fc',3); }); state.comets.forEach(function(c){ drawMini(c.x,c.y,'#fff',3); }); if(!state.inNebula) drawMini(state.ship.x,state.ship.y,'#9cf',4); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
     minimapFog(sx,sy);
     mctx.strokeStyle='rgba(255,255,255,.5)'; mctx.strokeRect(cam.x*sx, cam.y*sy, W*sx, H*sy);
   }
@@ -679,7 +692,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
   // Planet texture baker
   function bakePlanetTexture(p){
-    var sz=Math.ceil((p.r+14)*2); var c=document.createElement('canvas'); c.width=c.height=sz; var g=c.getContext('2d'); var cx=sz/2, cy=sz/2; var palettes={ rocky:["#9a7b56","#c9a97b","#6e5942"], ocean:["#1a3f6b","#0e5e7d","#1ea0a0"], ice:["#dfeaf7","#b7d3ec","#9fbfe0"], lava:["#302020","#552222","#ff5b1a"], gas:["#c18d5a","#d7a66b","#eacb87"], industrial:["#5c636a","#7a8086","#3f454b"] }; var cols=palettes[p.type]||palettes.rocky; var planetR=p.r; g.save(); g.translate(cx,cy); var latGrad=g.createRadialGradient(0,0,planetR*0.2,0,0,planetR); latGrad.addColorStop(0, cols[1]); latGrad.addColorStop(1, cols[0]); g.fillStyle=latGrad; g.beginPath(); g.arc(0,0,planetR,0,Math.PI*2); g.fill(); var blobs=(p.type==="gas")?500:260; for(var i=0;i<blobs;i++){ var ang=Math.random()*Math.PI*2; var rr=planetR*Math.sqrt(Math.random()); var x=Math.cos(ang)*rr; var y=Math.sin(ang)*rr; var rad=(p.type==="gas")?rand(6, planetR*0.22):rand(4, planetR*0.18); g.globalAlpha=(p.type==="gas")?rand(0.06,0.14):rand(0.08,0.18); g.fillStyle=pick(cols); if(p.type==="gas"){ g.save(); g.translate(x,y); g.rotate(rand(-0.25,0.25)); g.beginPath(); g.ellipse(0,0,rad*1.8,rad*0.6,0,0,Math.PI*2); g.fill(); g.restore(); } else { g.beginPath(); g.arc(x,y,rad,0,Math.PI*2); g.fill(); } }
+    var sz=Math.ceil((p.r+14)*2); var c=document.createElement('canvas'); c.width=c.height=sz; var g=c.getContext('2d'); var cx=sz/2, cy=sz/2; var palettes={ rocky:["#9a7b56","#c9a97b","#6e5942"], ocean:["#1a3f6b","#0e5e7d","#1ea0a0"], ice:["#dfeaf7","#b7d3ec","#9fbfe0"], lava:["#302020","#552222","#ff5b1a"], gas:["#c18d5a","#d7a66b","#eacb87"], industrial:["#5c636a","#7a8086","#3f454b"], star:["#fff4e5","#ffd27d","#ff9e2a"] }; var cols=palettes[p.type]||palettes.rocky; var planetR=p.r; g.save(); g.translate(cx,cy); var latGrad=g.createRadialGradient(0,0,planetR*0.2,0,0,planetR); latGrad.addColorStop(0, cols[1]); latGrad.addColorStop(1, cols[0]); g.fillStyle=latGrad; g.beginPath(); g.arc(0,0,planetR,0,Math.PI*2); g.fill(); var blobs=(p.type==="gas")?500:260; for(var i=0;i<blobs;i++){ var ang=Math.random()*Math.PI*2; var rr=planetR*Math.sqrt(Math.random()); var x=Math.cos(ang)*rr; var y=Math.sin(ang)*rr; var rad=(p.type==="gas")?rand(6, planetR*0.22):rand(4, planetR*0.18); g.globalAlpha=(p.type==="gas")?rand(0.06,0.14):rand(0.08,0.18); g.fillStyle=pick(cols); if(p.type==="gas"){ g.save(); g.translate(x,y); g.rotate(rand(-0.25,0.25)); g.beginPath(); g.ellipse(0,0,rad*1.8,rad*0.6,0,0,Math.PI*2); g.fill(); g.restore(); } else { g.beginPath(); g.arc(x,y,rad,0,Math.PI*2); g.fill(); } }
     g.globalAlpha=1; if(p.type==="ice"||p.type==="ocean"){ g.fillStyle=(p.type==="ice")?"rgba(255,255,255,.6)":"rgba(255,255,255,.2)"; g.beginPath(); g.arc(0,-planetR*0.75, planetR*0.45, 0, Math.PI*2); g.fill(); g.beginPath(); g.arc(0, planetR*0.75, planetR*0.45, 0, Math.PI*2); g.fill(); }
     if(p.type==="lava"){ for(var L=0;L<80;L++){ var a=Math.random()*Math.PI*2; var r2=planetR*rand(0.3,0.95); var x2=Math.cos(a)*r2, y2=Math.sin(a)*r2; g.strokeStyle="rgba(255,120,20,.7)"; g.lineWidth=rand(1.2,2.4); g.beginPath(); g.moveTo(x2,y2); g.lineTo(x2+rand(-12,12), y2+rand(-12,12)); g.stroke(); } }
     var Ld={x:0.8,y:-0.6}; var term=g.createRadialGradient(Ld.x*planetR*0.6, Ld.y*planetR*0.6, planetR*0.6, 0,0, planetR*1.1); term.addColorStop(0.0, "rgba(0,0,0,0)"); term.addColorStop(0.55,"rgba(0,0,0,0)"); term.addColorStop(1.0, "rgba(0,0,0,0.55)"); g.globalCompositeOperation="multiply"; g.fillStyle=term; g.beginPath(); g.arc(0,0,planetR,0,Math.PI*2); g.fill(); g.globalCompositeOperation="source-over"; if(p.type==="industrial"||p.type==="ocean"){ g.save(); g.rotate(Math.atan2(-Ld.y, -Ld.x)); g.translate(-planetR*0.25,0); for(var nl=0;nl<200;nl++){ var aa=Math.random()*Math.PI*2, rr2=planetR*Math.sqrt(Math.random()); var xx=Math.cos(aa)*rr2, yy=Math.sin(aa)*rr2; if(xx>0) continue; g.fillStyle=(Math.random()<0.3)?"rgba(255,220,180,.85)":"rgba(255,200,140,.55)"; g.fillRect(xx,yy,1,1); } g.restore(); }


### PR DESCRIPTION
## Summary
- Move nebulae and fade them into star birth with growing star textures
- Reuse planet baker for star visuals and add star texture palette
- Introduce rival hauler NPCs that take expired contracts and can be targeted by pirates
- Clear cargo when missions expire

## Testing
- `node index.html` *(fails: Unexpected token '<' — browser environment required)*

------
https://chatgpt.com/codex/tasks/task_e_68a26cac2b04832fae69d95671888a4b