### PR TITLE
Replace start screen title text with image

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
     .toast{padding:8px 12px;border-radius:10px;background:rgba(20,28,44,.9);outline:1px solid rgba(255,255,255,.08);box-shadow:0 6px 18px rgba(0,0,0,.4)}
     .overlay{position:absolute;inset:0;display:grid;place-items:center;background:radial-gradient(900px 600px at 50% 30%,rgba(10,14,22,.55),rgba(7,10,16,.85));backdrop-filter:blur(2px);z-index:5}
     #startScreen .actions{display:flex;gap:10px;margin-top:10px;flex-wrap:wrap}
+    #startScreen img.start-image{width:100%;height:auto;}
     #leaderboard{margin-top:12px}
     #leaderboard table{width:100%;border-collapse:collapse}
     #leaderboard th,#leaderboard td{padding:6px 8px;text-align:left;border-bottom:1px solid rgba(255,255,255,.08)}
@@ -109,7 +110,7 @@
 
     <div id="startScreen" class="overlay">
       <div class="panel">
-        <h1>STARHAUL</h1>
+        <img src="StarHauler_Startscreen.png" alt="StarHaul" class="start-image" />
         <p class="sub">RTS‑lite cargo runner. Explore a vast sector with planets, contracts, pirates, black holes — and deadly, evolving stars.</p>
         <div class="grid">
           <div>


### PR DESCRIPTION
## Summary
- Show `StarHauler_Startscreen.png` in the start screen in place of text title
- Scale start screen image to fit the window width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aa869bb4832f951df2de24b558f4