### PR TITLE
Handle missing UI controls when binding handlers

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -56,20 +56,19 @@ export function toast(msg) {
 }
 
 export function bindUIHandlers(handlers) {
-  if (!ui.pauseBtn) return;
-  ui.pauseBtn.addEventListener('click', handlers.showPause);
-  ui.restartBtn.addEventListener('click', handlers.restartGame);
-  ui.undockBtn.addEventListener('click', handlers.undock);
-  ui.setHomeBtn.addEventListener('click', handlers.setHome);
-  ui.missionPill.addEventListener('click', handlers.toggleMissionLog);
-  ui.newGameBtn.addEventListener('click', handlers.startNewGame);
-  ui.viewScoresBtn.addEventListener('click', handlers.viewScores);
-  ui.quitBtn.addEventListener('click', handlers.quitToMenu);
-  ui.resumeBtn.addEventListener('click', handlers.hidePause);
-  ui.pauseRestartBtn.addEventListener('click', handlers.pauseRestart);
-  ui.toMenuBtn.addEventListener('click', handlers.pauseToMenu);
-  ui.saveScoreBtn.addEventListener('click', handlers.saveScore);
-  ui.goMenuBtn.addEventListener('click', handlers.showMenu);
+  if (ui.pauseBtn) ui.pauseBtn.addEventListener('click', handlers.showPause);
+  if (ui.restartBtn) ui.restartBtn.addEventListener('click', handlers.restartGame);
+  if (ui.undockBtn) ui.undockBtn.addEventListener('click', handlers.undock);
+  if (ui.setHomeBtn) ui.setHomeBtn.addEventListener('click', handlers.setHome);
+  if (ui.missionPill) ui.missionPill.addEventListener('click', handlers.toggleMissionLog);
+  if (ui.newGameBtn) ui.newGameBtn.addEventListener('click', handlers.startNewGame);
+  if (ui.viewScoresBtn) ui.viewScoresBtn.addEventListener('click', handlers.viewScores);
+  if (ui.quitBtn) ui.quitBtn.addEventListener('click', handlers.quitToMenu);
+  if (ui.resumeBtn) ui.resumeBtn.addEventListener('click', handlers.hidePause);
+  if (ui.pauseRestartBtn) ui.pauseRestartBtn.addEventListener('click', handlers.pauseRestart);
+  if (ui.toMenuBtn) ui.toMenuBtn.addEventListener('click', handlers.pauseToMenu);
+  if (ui.saveScoreBtn) ui.saveScoreBtn.addEventListener('click', handlers.saveScore);
+  if (ui.goMenuBtn) ui.goMenuBtn.addEventListener('click', handlers.showMenu);
   document.querySelectorAll('[data-buy]').forEach(b => {
     b.onclick = () => handlers.marketBuy(b.getAttribute('data-buy'));
   });


### PR DESCRIPTION
## Summary
- Guard each UI element before binding click handlers instead of returning when `pauseBtn` is missing.
- Ensures essential buttons like `newGameBtn` still register their actions even if optional controls are absent.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64d9948f4832fb16f6384e7951db7