### PR TITLE
Delay game start until user action

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -2,12 +2,12 @@ import { ui, toast, bindUIHandlers } from './ui.js';
 import { CFG, newShip, makePlanet, makeStar } from './entities.js';
 
 // Canvas setup for simple rendering without sprite graphics
-const canvas = document.getElementById('game');
-const ctx = canvas.getContext('2d');
+let canvas;
+let ctx;
 
 let state = null;
 
-export function startNewGame() {
+function startNewGame() {
   state = { ship: newShip(), planets: [], stars: [] };
   // centre the ship on the canvas
   state.ship.x = canvas.width / 2;
@@ -35,21 +35,26 @@ function saveScore() {}
 function showMenu() {}
 function marketBuy() {}
 
-bindUIHandlers({
-  showPause,
-  restartGame,
-  undock,
-  setHome,
-  toggleMissionLog,
-  startNewGame,
-  viewScores,
-  quitToMenu,
-  hidePause,
-  pauseRestart,
-  pauseToMenu,
-  saveScore,
-  showMenu,
-  marketBuy
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('game');
+  ctx = canvas.getContext('2d');
+
+  bindUIHandlers({
+    showPause,
+    restartGame,
+    undock,
+    setHome,
+    toggleMissionLog,
+    startNewGame: initGame,
+    viewScores,
+    quitToMenu,
+    hidePause,
+    pauseRestart,
+    pauseToMenu,
+    saveScore,
+    showMenu,
+    marketBuy
+  });
 });
 
 function drawShip(ship) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,2 @@
-import { initGame } from './game.js';
+import './game.js';
 
-initGame();


### PR DESCRIPTION
## Summary
- Remove automatic initGame call and import game module for side effects
- Bind UI handlers after DOMContentLoaded and start game from New Game button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64d99f94c832f8d3dc906b5a77a9c