### PR TITLE
Enhance mini-map and add universe map overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
     .item:nth-child(odd){background:rgba(255,255,255,.03)}
     .badge{padding:2px 6px;border-radius:999px;background:rgba(255,255,255,.08);font-size:12px}
     #missionPill{cursor:pointer}
-    #radar{position:absolute;right:16px;bottom:16px;width:200px;height:200px;border-radius:12px;background:rgba(10,14,22,.65);outline:1px solid rgba(255,255,255,.08);display:grid;place-items:center;font-size:12px;z-index:2}
+    #radar{position:absolute;right:16px;bottom:16px;width:240px;height:240px;border-radius:50%;background:rgba(10,14,22,.65);outline:1px solid rgba(255,255,255,.08);display:grid;place-items:center;font-size:12px;z-index:2;overflow:hidden}
+    #radar canvas{border-radius:50%}
     #touchpad{position:absolute;bottom:20px;left:20px;right:20px;display:none;justify-content:space-between;pointer-events:none}
     .pad{display:grid;grid-template-columns:repeat(2,68px);grid-template-rows:repeat(2,68px);gap:10px;pointer-events:auto}
     .tbtn{width:68px;height:68px;border-radius:16px;background:rgba(255,255,255,.06);outline:1px solid rgba(255,255,255,.12)}
@@ -95,8 +96,10 @@
       </div>
     </div>
 
-    <div id="radar"><canvas id="mini" width="180" height="180" aria-hidden="true"></canvas></div>
+    <div id="radar"><canvas id="mini" width="220" height="220" aria-hidden="true"></canvas></div>
     <div id="toasts"></div>
+
+    <div id="mapOverlay" class="overlay hidden"><canvas id="bigmap" width="800" height="600" aria-hidden="true"></canvas></div>
 
     <div id="touchpad" aria-hidden="true">
       <div class="pad" id="leftPad">
@@ -182,12 +185,12 @@ document.addEventListener('DOMContentLoaded', function(){
 
   var DEBUG = (location.hash.indexOf('dev')>=0);
 
-  var W=960, H=600; var WORLD={w:10400,h:7800};
+  var W=960, H=600; var WORLD={w:10400,h:7800}; var MINI_SIZE=220, MINI_RANGE=3000;
   var $=function(sel){ return document.querySelector(sel); };
   var wrap=$('.wrap'); if(!wrap){ wrap=document.createElement('div'); wrap.className='wrap'; document.body.appendChild(wrap); }
   var canvas=$('#game'); if(!canvas){ canvas=document.createElement('canvas'); canvas.id='game'; canvas.width=960; canvas.height=600; wrap.insertBefore(canvas, wrap.firstChild||null); }
   var ctx=canvas.getContext('2d'); if(!ctx){ alert('Canvas failed to initialize.'); return; }
-  var mini=$('#mini'); if(!mini){ var radar=document.createElement('div'); radar.id='radar'; radar.style.position='absolute'; radar.style.right='16px'; radar.style.bottom='16px'; radar.style.width='200px'; radar.style.height='200px'; radar.style.borderRadius='12px'; radar.style.background='rgba(10,14,22,.65)'; radar.style.outline='1px solid rgba(255,255,255,.08)'; radar.style.display='grid'; radar.style.placeItems='center'; mini=document.createElement('canvas'); mini.id='mini'; mini.width=180; mini.height=180; radar.appendChild(mini); wrap.appendChild(radar); }
+  var mini=$('#mini'); if(!mini){ var radar=document.createElement('div'); radar.id='radar'; radar.style.position='absolute'; radar.style.right='16px'; radar.style.bottom='16px'; radar.style.width='240px'; radar.style.height='240px'; radar.style.borderRadius='50%'; radar.style.background='rgba(10,14,22,.65)'; radar.style.outline='1px solid rgba(255,255,255,.08)'; radar.style.display='grid'; radar.style.placeItems='center'; radar.style.overflow='hidden'; mini=document.createElement('canvas'); mini.id='mini'; mini.width=MINI_SIZE; mini.height=MINI_SIZE; mini.style.borderRadius='50%'; radar.appendChild(mini); wrap.appendChild(radar); } else { mini.width=MINI_SIZE; mini.height=MINI_SIZE; mini.style.borderRadius='50%'; }
   var mctx=mini.getContext('2d');
 
   var ui={
@@ -195,10 +198,15 @@ document.addEventListener('DOMContentLoaded', function(){
       credits:$('#credits'), fuel:$('#fuel'), ammo:$('#ammo'), cargo:$('#cargo'), cargoMax:$('#cargoMax'), hull:$('#hull'), hullMax:$('#hullMax'), lives:$('#lives'), rep:$('#rep'), missionCount:$('#missionCount'),
     pauseBtn:$('#pauseBtn'), restartBtn:$('#restartBtn'), missionPill:$('#missionPill'), toasts:$('#toasts'),
       missionList:$('#missionList'), upgrades:$('#upgrades'), undockBtn:$('#undockBtn'), setHomeBtn:$('#setHomeBtn'), lifeFill:$('#lifeFill'),
+    mapOverlay:$('#mapOverlay'), bigmap:$('#bigmap'),
     startScreen:$('#startScreen'), newGameBtn:$('#newGameBtn'), viewScoresBtn:$('#viewScoresBtn'), quitBtn:$('#quitBtn'), scoresBody:$('#scoresBody'), leaderboard:$('#leaderboard'),
     pauseOverlay:$('#pauseOverlay'), resumeBtn:$('#resumeBtn'), pauseRestartBtn:$('#pauseRestartBtn'), toMenuBtn:$('#toMenuBtn'), pauseStats:$('#pauseStats'),
     gameOver:$('#gameOver'), finalStats:$('#finalStats'), pilotName:$('#pilotName'), saveScoreBtn:$('#saveScoreBtn'), goMenuBtn:$('#goMenuBtn')
   };
+
+  var bctx=ui.bigmap.getContext('2d');
+  ui.radar.addEventListener('click', function(){ drawBigMap(); ui.mapOverlay.classList.remove('hidden'); });
+  ui.mapOverlay.addEventListener('click', function(){ ui.mapOverlay.classList.add('hidden'); });
 
   window.addEventListener('error', function(e){ try{ toast('JS error: '+((e && e.message)||'Script error')); console.error('StarHaul error:', e); }catch(_){} });
 
@@ -723,12 +731,14 @@ document.addEventListener('DOMContentLoaded', function(){
     // NAV ARROW to tracked destination (only if discovered)
     if(state.tracked){ var tm=state.missions.find(function(m){return m.id===state.tracked;}); if(tm){ var dest=planetById(tm.to); if(dest && state.discovered.has(dest.id)){ drawNavArrow(dest.x, dest.y, planetById(tm.to).name); } } }
 
-    // minimap & fog
-    mctx.clearRect(0,0,180,180); mctx.strokeStyle='rgba(255,255,255,.15)'; mctx.strokeRect(0,0,180,180); var sx=180/WORLD.w, sy=180/WORLD.h;
-    function drawMini(x,y,color,sz){ mctx.fillStyle=color; sz=sz||3; mctx.fillRect(x*sx- sz/2, y*sy- sz/2, sz, sz); }
-    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.rifts.forEach(function(r){ drawMini(r.x,r.y,'#88f',3); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.bases.forEach(function(b){ drawMini(b.x,b.y,'#f44',4); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); state.hunters.forEach(function(h){ drawMini(h.x,h.y,'#fff',3); }); state.patrols.forEach(function(p){ drawMini(p.x,p.y,'#4f8',3); }); state.haulers.forEach(function(h){ drawMini(h.x,h.y,'#9fc',3); }); state.comets.forEach(function(c){ drawMini(c.x,c.y,'#fff',3); }); state.meteorEvents.forEach(function(ev){ drawMini(ev.x,ev.y,'#fa0',5); }); if(!state.inNebula) drawMini(state.ship.x,state.ship.y,'#9cf',4); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
-    minimapFog(sx,sy);
-    mctx.strokeStyle='rgba(255,255,255,.5)'; mctx.strokeRect(cam.x*sx, cam.y*sy, W*sx, H*sy);
+    // minimap centered on ship
+    mctx.clearRect(0,0,MINI_SIZE,MINI_SIZE);
+    var range=MINI_RANGE; var sx=MINI_SIZE/range, sy=MINI_SIZE/range; var half=MINI_SIZE/2;
+    function drawMini(x,y,color,sz){ var dx=(x-state.ship.x)*sx+half; var dy=(y-state.ship.y)*sy+half; if(dx<-4||dx>MINI_SIZE+4||dy<-4||dy>MINI_SIZE+4) return; mctx.fillStyle=color; sz=sz||4; mctx.fillRect(dx- sz/2, dy- sz/2, sz, sz); }
+    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawMini(p.x,p.y,'#8be',4); }); state.blackholes.forEach(function(h){ drawMini(h.x,h.y,'#000',5); }); state.rifts.forEach(function(r){ drawMini(r.x,r.y,'#88f',3); }); state.stars.forEach(function(st){ drawMini(st.x,st.y,'#ffd56b',4); }); state.asteroids.forEach(function(a){ drawMini(a.x,a.y,'#ccd',2); }); state.bases.forEach(function(b){ drawMini(b.x,b.y,'#f44',4); }); state.pirates.forEach(function(p){ drawMini(p.x,p.y,'#f88',3); }); state.hunters.forEach(function(h){ drawMini(h.x,h.y,'#fff',3); }); state.patrols.forEach(function(p){ drawMini(p.x,p.y,'#4f8',3); }); state.haulers.forEach(function(h){ drawMini(h.x,h.y,'#9fc',3); }); state.comets.forEach(function(c){ drawMini(c.x,c.y,'#fff',3); }); state.meteorEvents.forEach(function(ev){ drawMini(ev.x,ev.y,'#fa0',5); }); state.gates.forEach(function(g){ drawMini(g.x,g.y,'#9bf',3); });
+    // ship dot at center
+    mctx.fillStyle='#9cf'; mctx.fillRect(half-2, half-2, 4, 4);
+    mctx.strokeStyle='rgba(255,255,255,.15)'; mctx.beginPath(); mctx.arc(half,half,half-1,0,Math.PI*2); mctx.stroke();
   }
 
   function drawNavArrow(tx,ty,label){
@@ -740,8 +750,31 @@ document.addEventListener('DOMContentLoaded', function(){
     ctx2.restore();
   }
 
+  function drawBigMap(){
+    var bw=ui.bigmap.width, bh=ui.bigmap.height;
+    bctx.clearRect(0,0,bw,bh);
+    var sx=bw/WORLD.w, sy=bh/WORLD.h;
+    function drawBig(x,y,color,sz){ bctx.fillStyle=color; sz=sz||4; bctx.fillRect(x*sx- sz/2, y*sy- sz/2, sz, sz); }
+    state.planets.forEach(function(p){ if(state.discovered.has(p.id)) drawBig(p.x,p.y,'#8be',5); });
+    state.blackholes.forEach(function(h){ drawBig(h.x,h.y,'#000',6); });
+    state.rifts.forEach(function(r){ drawBig(r.x,r.y,'#88f',4); });
+    state.stars.forEach(function(st){ drawBig(st.x,st.y,'#ffd56b',5); });
+    state.asteroids.forEach(function(a){ drawBig(a.x,a.y,'#ccd',3); });
+    state.bases.forEach(function(b){ drawBig(b.x,b.y,'#f44',5); });
+    state.pirates.forEach(function(p){ drawBig(p.x,p.y,'#f88',4); });
+    state.hunters.forEach(function(h){ drawBig(h.x,h.y,'#fff',4); });
+    state.patrols.forEach(function(p){ drawBig(p.x,p.y,'#4f8',4); });
+    state.haulers.forEach(function(h){ drawBig(h.x,h.y,'#9fc',4); });
+    state.comets.forEach(function(c){ drawBig(c.x,c.y,'#fff',4); });
+    state.meteorEvents.forEach(function(ev){ drawBig(ev.x,ev.y,'#fa0',6); });
+    state.gates.forEach(function(g){ drawBig(g.x,g.y,'#9bf',4); });
+    drawBig(state.ship.x,state.ship.y,'#9cf',5);
+    drawFog(bctx,sx,sy);
+    bctx.strokeStyle='rgba(255,255,255,.5)'; bctx.strokeRect(cam.x*sx, cam.y*sy, W*sx, H*sy);
+  }
+
   function cellOf(x,y){ var cs=180; return Math.floor(x/cs)+":"+Math.floor(y/cs); }
-  function minimapFog(sx,sy){ var cs=180; var cols=Math.ceil(WORLD.w/cs), rows=Math.ceil(WORLD.h/cs); mctx.fillStyle='rgba(0,0,0,.35)'; for(var cy=0; cy<rows; cy++){ for(var cx=0; cx<cols; cx++){ var key=cx+":"+cy; if(!state.fow.has(key)){ mctx.fillRect(cx*cs*sx, cy*cs*sy, cs*sx, cs*sy); } } } }
+  function drawFog(ctx,sx,sy){ var cs=180; var cols=Math.ceil(WORLD.w/cs), rows=Math.ceil(WORLD.h/cs); ctx.fillStyle='rgba(0,0,0,.35)'; for(var cy=0; cy<rows; cy++){ for(var cx=0; cx<cols; cx++){ var key=cx+":"+cy; if(!state.fow.has(key)){ ctx.fillRect(cx*cs*sx, cy*cs*sy, cs*sx, cs*sy); } } } }
   function discoverVisiblePlanets(){ for(var i=0;i<state.planets.length;i++){ var p=state.planets[i]; if(state.discovered.has(p.id)) continue; if(p.x>cam.x-p.r && p.x<cam.x+W+p.r && p.y>cam.y-p.r && p.y<cam.y+H+p.r){ state.discovered.add(p.id); toast('📡 Charted '+p.name); } } }
 
   function updateCamera(){ cam.x=clamp(state.ship.x - W/2, 0, WORLD.w - W); cam.y=clamp(state.ship.y - H/2, 0, WORLD.h - H); }
@@ -825,7 +858,7 @@ document.addEventListener('DOMContentLoaded', function(){
 
     startNewGame();
     assert(!!canvas && !!ctx, 'canvas & context present');
-    assert(!!mini && !!mctx, 'minimap context present');
+    assert(!!mini && !!mctx && !!bctx, 'minimap context present');
     // planet textures exist
     assert(state.planets.every(function(p){return !!p.tex;}), 'planet textures baked');
     // asteroid size < planet size


### PR DESCRIPTION
## Summary
- Enlarge mini-map, render as a circular radar and center the ship.
- Improve mini-map clarity and add central ship marker.
- Enable clicking the mini-map to view a larger universe map with fog-of-war.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a79120b7a0832fb9351cf41bc274a7