### PR TITLE
Limit canvas styles to main game canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     :root{ --bg:#05070e; --fg:#e6edf3; --muted:#9aa5b1; --accent:#6df2d6; --accent2:#6db8f2; --warn:#ffd56b; --bad:#ff6b6b; --ok:#6bff9a; --danger:#ff9f6b }
     html,body{height:100%;margin:0;background:radial-gradient(1200px 800px at 70% 10%,#0e1430 0%,#0b0f1f 45%,#070a14 100%);color:var(--fg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";overflow:hidden}
     .wrap{position:absolute;inset:0;display:grid;place-items:center;padding:12px}
-    canvas{width:min(100vw-24px,1200px);height:calc((min(100vw - 24px, 1200px))*0.625);max-height:min(100vh-24px,800px);aspect-ratio:16/10;background:linear-gradient(180deg, rgba(17,19,33,.8), rgba(6,8,16,.9));box-shadow:0 10px 40px rgba(0,0,0,.55), inset 0 0 120px rgba(0,0,0,.35);border-radius:18px;outline:1px solid rgba(255,255,255,.08)}
+    #game{width:min(100vw-24px,1200px);height:calc((min(100vw - 24px, 1200px))*0.625);max-height:min(100vh-24px,800px);aspect-ratio:16/10;background:linear-gradient(180deg, rgba(17,19,33,.8), rgba(6,8,16,.9));box-shadow:0 10px 40px rgba(0,0,0,.55), inset 0 0 120px rgba(0,0,0,.35);border-radius:18px;outline:1px solid rgba(255,255,255,.08)}
     .hidden{display:none !important}
     #hud{position:absolute;top:10px;left:10px;right:10px;display:flex;gap:8px;align-items:center;justify-content:space-between;font-weight:700;user-select:none;pointer-events:none}
     .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:rgba(12,15,28,.6);outline:1px solid rgba(255,255,255,.08);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);pointer-events:auto;box-shadow:0 0 0 1px rgba(109,242,214,.06) inset}
@@ -31,6 +31,7 @@
     #missionPill{cursor:pointer}
     #radar{position:absolute;right:16px;bottom:16px;width:480px;height:480px;border-radius:50%;background:rgba(10,14,22,.65);outline:1px solid rgba(255,255,255,.08);display:grid;place-items:center;font-size:12px;z-index:2;overflow:hidden}
     #radar canvas{border-radius:50%}
+    #mini{height:auto;}
     #touchpad{position:absolute;bottom:20px;left:20px;right:20px;display:none;justify-content:space-between;pointer-events:none}
     .pad{display:grid;grid-template-columns:repeat(2,68px);grid-template-rows:repeat(2,68px);gap:10px;pointer-events:auto}
     .tbtn{width:68px;height:68px;border-radius:16px;background:rgba(255,255,255,.06);outline:1px solid rgba(255,255,255,.12)}


### PR DESCRIPTION
## Summary
- Scope previous global canvas styles to `#game` to avoid affecting other canvases
- Allow mini-map canvas to auto-size by setting `#mini` height to `auto`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8de2c9f64832fb8a414d03df51281