### PR TITLE
Make game canvas fill entire page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <style>
     :root{ --bg:#05070e; --fg:#e6edf3; --muted:#9aa5b1; --accent:#6df2d6; --accent2:#6db8f2; --warn:#ffd56b; --bad:#ff6b6b; --ok:#6bff9a; --danger:#ff9f6b }
     html,body{height:100%;margin:0;background:radial-gradient(1200px 800px at 70% 10%,#0e1430 0%,#0b0f1f 45%,#070a14 100%);color:var(--fg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";overflow:hidden}
-    .wrap{position:absolute;inset:0;display:grid;place-items:center;padding:12px}
-    #game{width:min(100vw-24px,1200px);height:calc((min(100vw - 24px, 1200px))*0.625);max-height:min(100vh-24px,800px);aspect-ratio:16/10;background:linear-gradient(180deg, rgba(17,19,33,.8), rgba(6,8,16,.9));box-shadow:0 10px 40px rgba(0,0,0,.55), inset 0 0 120px rgba(0,0,0,.35);border-radius:18px;outline:1px solid rgba(255,255,255,.08)}
+    .wrap{position:absolute;inset:0;padding:0}
+    #game{width:100vw;height:100vh;max-width:none;max-height:none;background:linear-gradient(180deg, rgba(17,19,33,.8), rgba(6,8,16,.9));box-shadow:none;border-radius:0;outline:none}
     .hidden{display:none !important}
     #hud{position:absolute;top:10px;left:10px;right:10px;display:flex;gap:8px;align-items:center;justify-content:space-between;font-weight:700;user-select:none;pointer-events:none}
     .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:rgba(12,15,28,.6);outline:1px solid rgba(255,255,255,.08);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);pointer-events:auto;box-shadow:0 0 0 1px rgba(109,242,214,.06) inset}
@@ -201,12 +201,15 @@ document.addEventListener('DOMContentLoaded', function(){
 
   var DEBUG = (location.hash.indexOf('dev')>=0);
 
-  var W=960, H=600; var WORLD={w:10400,h:7800}; var MINI_SIZE=440;
-  var RADAR_BASE_RANGE = Math.hypot(W/2, H/2) * 2 * 1.25;
+  var W=window.innerWidth, H=window.innerHeight; var WORLD={w:10400,h:7800}; var MINI_SIZE=440;
+  var RADAR_BASE_RANGE;
   var $=function(sel){ return document.querySelector(sel); };
   var wrap=$('.wrap'); if(!wrap){ wrap=document.createElement('div'); wrap.className='wrap'; document.body.appendChild(wrap); }
-  var canvas=$('#game'); if(!canvas){ canvas=document.createElement('canvas'); canvas.id='game'; canvas.width=960; canvas.height=600; wrap.insertBefore(canvas, wrap.firstChild||null); }
+  var canvas=$('#game'); if(!canvas){ canvas=document.createElement('canvas'); canvas.id='game'; wrap.insertBefore(canvas, wrap.firstChild||null); }
   var ctx=canvas.getContext('2d'); if(!ctx){ alert('Canvas failed to initialize.'); return; }
+  function resize(){ W=window.innerWidth; H=window.innerHeight; canvas.width=W; canvas.height=H; RADAR_BASE_RANGE=Math.hypot(W/2, H/2)*2*1.25; }
+  resize();
+  window.addEventListener('resize', resize);
   var mini=$('#mini'); if(!mini){ var radar=document.createElement('div'); radar.id='radar'; radar.style.position='absolute'; radar.style.right='16px'; radar.style.bottom='16px'; radar.style.width='480px'; radar.style.height='480px'; radar.style.borderRadius='50%'; radar.style.background='rgba(10,14,22,.65)'; radar.style.outline='1px solid rgba(255,255,255,.08)'; radar.style.display='grid'; radar.style.placeItems='center'; radar.style.overflow='hidden'; mini=document.createElement('canvas'); mini.id='mini'; mini.width=MINI_SIZE; mini.height=MINI_SIZE; mini.style.borderRadius='50%'; radar.appendChild(mini); wrap.appendChild(radar); } else { mini.width=MINI_SIZE; mini.height=MINI_SIZE; mini.style.borderRadius='50%'; }
   var mctx=mini.getContext('2d');
 


### PR DESCRIPTION
## Summary
- Expand game canvas styles so the game window fills the entire browser viewport
- Add resize handler to match canvas dimensions to window size at runtime

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f5e609b0832fb410520c8a34a264