### PR TITLE
Ensure radar canvas fills radar container

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     #missionPill{cursor:pointer}
     #radar{position:absolute;right:0;bottom:0;width:300px;height:300px;border-radius:50%;background:#0a0e16;display:grid;place-items:center;font-size:12px;z-index:2;overflow:hidden}
     #radar canvas{border-radius:50%}
-    #mini{height:auto;}
+    #mini{width:100%;height:100%;}
     #touchpad{position:absolute;bottom:20px;left:20px;right:20px;display:none;justify-content:space-between;pointer-events:none}
     .pad{display:grid;grid-template-columns:repeat(2,68px);grid-template-rows:repeat(2,68px);gap:10px;pointer-events:auto}
     .tbtn{width:68px;height:68px;border-radius:16px;background:rgba(255,255,255,.06);outline:1px solid rgba(255,255,255,.12)}


### PR DESCRIPTION
## Summary
- Make minimap canvas stretch to radar container using `width:100%;height:100%`

## Testing
- `node check-radar.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac7c014364832f9ee9a4cf3e4e88f5