### PR TITLE
Use fixed timestep loop with object pooling and culling

### DIFF
--- a/core/loop.js
+++ b/core/loop.js
@@ -1,17 +1,23 @@
 let running = false;
 let paused = false;
 let lastTime = 0;
+let accumulator = 0;
+const STEP = 1000 / 60;
 let updateFn = () => {};
 let drawFn = () => {};
 
 function loop(ts){
   if(!running) return;
   if(!lastTime) lastTime = ts;
-  let dt = (ts - lastTime) / (1000/60);
-  if(dt <= 0 || dt > 5) dt = 1;
+  let delta = ts - lastTime;
+  if(delta > 1000) delta = STEP;
   lastTime = ts;
-  if(!paused) updateFn(dt);
-  drawFn();
+  accumulator += delta;
+  while(accumulator >= STEP){
+    if(!paused) updateFn(STEP / (1000/60));
+    accumulator -= STEP;
+  }
+  drawFn(accumulator / STEP);
   requestAnimationFrame(loop);
 }
 
@@ -21,6 +27,7 @@ export function start(update, draw){
   running = true;
   paused = false;
   lastTime = 0;
+  accumulator = 0;
   requestAnimationFrame(loop);
 }
 

--- a/core/pool.js
+++ b/core/pool.js
@@ -1,0 +1,17 @@
+export function createPool(factory, initialSize = 0){
+  const pool = [];
+  for(let i=0;i<initialSize;i++){
+    pool.push(factory());
+  }
+  return {
+    acquire(){
+      return pool.length ? pool.pop() : factory();
+    },
+    release(obj){
+      pool.push(obj);
+    },
+    size(){
+      return pool.length;
+    }
+  };
+}

--- a/main.js
+++ b/main.js
@@ -4,9 +4,11 @@ import { reset } from './world/gen.js';
 import { refreshOffers } from './systems/contracts.js';
 import { updateHUD } from './ui/hud.js';
 import { renderDock, dockToggle, dock, undock, marketBuy } from './ui/dock.js';
+import { updateWorld, drawWorld } from './world/world.js';
 
 let state = null;
 let running = false;
+let ctx = null;
 
 const ui = {
   dockUI: document.getElementById('dockUI'),
@@ -25,16 +27,20 @@ const ui = {
 };
 
 function update(){
+  updateWorld(state, 1);
   refreshOffers(state);
   updateHUD(ui, state);
 }
 
 function draw(){
-  // drawing handled elsewhere
+  drawWorld(ctx, state);
 }
 
 function startGame(){
+  const canvas = document.getElementById('game');
+  ctx = canvas.getContext('2d');
   state = reset();
+  state.camera = {x:0, y:0, w:canvas.width, h:canvas.height};
   running = true;
   start(update, draw);
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "starhaul",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,0 +1,40 @@
+import { performance } from 'node:perf_hooks';
+import { updateWorld, drawWorld } from '../world/world.js';
+import { createPool } from '../core/pool.js';
+
+function makeEntities(n, r){
+  const arr = [];
+  for(let i=0;i<n;i++){
+    arr.push({x: Math.random()*4000, y: Math.random()*4000, r});
+  }
+  return arr;
+}
+
+const state = {
+  camera: {x:0, y:0, w:1920, h:1080},
+  stars: makeEntities(300, 2),
+  planets: makeEntities(10, 40),
+  bullets: [],
+  particles: [],
+  bulletPool: createPool(() => ({x:0,y:0,vx:0,vy:0,r:1,life:1})),
+  particlePool: createPool(() => ({x:0,y:0,vx:0,vy:0,r:1,life:1}))
+};
+
+const ctx = {
+  clearRect(){},
+  fillRect(){},
+  beginPath(){},
+  arc(){},
+  fill(){},
+  set fillStyle(v){},
+  get fillStyle(){return '#000';}
+};
+
+const frames = 600;
+const start = performance.now();
+for(let i=0;i<frames;i++){
+  updateWorld(state, 1);
+  drawWorld(ctx, state);
+}
+const end = performance.now();
+console.log('Average frame ms:', (end-start)/frames);

--- a/world/gen.js
+++ b/world/gen.js
@@ -1,5 +1,6 @@
 import { newShip } from '../entities/player.js';
 import { makePirate } from '../entities/npc.js';
+import { createPool } from '../core/pool.js';
 
 export function makePlanet(id){
   return { id, x: Math.random()*WORLD.w, y: Math.random()*WORLD.h, r: 40, offers: [] };
@@ -23,6 +24,8 @@ export function reset(){
     cargoMax: CFG.economy.cargoMax,
     bullets: [],
     particles: [],
+    bulletPool: createPool(() => ({x:0, y:0, vx:0, vy:0, r:2, life:0})),
+    particlePool: createPool(() => ({x:0, y:0, vx:0, vy:0, r:1, life:0})),
     asteroids: [],
     planets: [],
     blackholes: [],

--- a/world/world.js
+++ b/world/world.js
@@ -1,0 +1,62 @@
+function isVisible(cam, obj){
+  return (
+    obj.x + obj.r > cam.x &&
+    obj.x - obj.r < cam.x + cam.w &&
+    obj.y + obj.r > cam.y &&
+    obj.y - obj.r < cam.y + cam.h
+  );
+}
+
+export function updateWorld(state, dt){
+  const cam = state.camera;
+  for(let i=state.bullets.length-1;i>=0;i--){
+    const b = state.bullets[i];
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
+    b.life -= dt;
+    if(b.life <= 0){
+      state.bullets.splice(i,1);
+      state.bulletPool.release(b);
+      continue;
+    }
+    if(!isVisible(cam, b)) continue;
+    // placeholder for in-view bullet logic
+  }
+  for(let i=state.particles.length-1;i>=0;i--){
+    const p = state.particles[i];
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+    p.life -= dt;
+    if(p.life <= 0){
+      state.particles.splice(i,1);
+      state.particlePool.release(p);
+    }
+  }
+}
+
+export function drawWorld(ctx, state){
+  const cam = state.camera;
+  ctx.clearRect(0,0,cam.w,cam.h);
+  for(const s of state.stars){
+    if(!isVisible(cam, s)) continue;
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(s.x - cam.x, s.y - cam.y, 2, 2);
+  }
+  for(const p of state.planets){
+    if(!isVisible(cam, p)) continue;
+    ctx.fillStyle = '#0af';
+    ctx.beginPath();
+    ctx.arc(p.x - cam.x, p.y - cam.y, p.r, 0, Math.PI*2);
+    ctx.fill();
+  }
+  ctx.fillStyle = '#ff0';
+  for(const b of state.bullets){
+    if(!isVisible(cam, b)) continue;
+    ctx.fillRect(b.x - cam.x -1, b.y - cam.y -1, 2,2);
+  }
+  ctx.fillStyle = '#f80';
+  for(const p of state.particles){
+    if(!isVisible(cam, p)) continue;
+    ctx.fillRect(p.x - cam.x, p.y - cam.y, 1,1);
+  }
+}


### PR DESCRIPTION
## Summary
- Implement fixed timestep game loop using an accumulator for consistent updates
- Add reusable object pools and integrate pools for bullets and particles
- Introduce camera-based culling in update and draw routines with profiling script

## Testing
- `node scripts/profile.js`

------
https://chatgpt.com/codex/tasks/task_e_68adbc375fcc832f84af8f4d1ffbf47d