### PR TITLE
Add debug overlay and cheat key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ StarHaul is a lightweight browser game where you pilot a small cargo ship across
 - **Shift** – Hyperspace jump
 - **P** – Pause
 
+## Debug Commands
+
+Enable **Debug mode** from the settings screen to access these commands:
+
+- `~` – Toggle debug overlay (FPS, entity counts, state flags)
+- `Ctrl+1` – Refill fuel
+- `Ctrl+2` – Add cargo
+- `Ctrl+3` – Spawn a nearby hazard
+
 ## Credits
 
 Created by the original StarHaul developers. This repository contains modifications for readability and documentation.

--- a/core/input.js
+++ b/core/input.js
@@ -4,6 +4,13 @@ export function initInput(opts){
     if(e.repeat) return;
     const s = opts.getState().ship;
     if(s.flare>0) return;
+    if(e.ctrlKey && opts.isDebug && opts.isDebug()){
+      switch(e.code){
+        case 'Digit1': opts.cheatFuel && opts.cheatFuel(); return;
+        case 'Digit2': opts.cheatCargo && opts.cheatCargo(); return;
+        case 'Digit3': opts.cheatHazard && opts.cheatHazard(); return;
+      }
+    }
     switch(e.code){
       case 'ArrowLeft': case 'KeyA': s.turn=-1; break;
       case 'ArrowRight': case 'KeyD': s.turn=1; break;

--- a/main.js
+++ b/main.js
@@ -7,10 +7,12 @@ import { renderDock, dockToggle, dock, undock, marketBuy } from './ui/dock.js';
 import { updateWorld, drawWorld } from './world/world.js';
 import { loadAll, getImage } from './core/assets.js';
 import { saveGame, loadGame } from './core/save.js';
+import { initDebug } from './ui/debug.js';
 
 let state = null;
 let running = false;
 let ctx = null;
+let debugMode = false;
 
 const ui = {
   dockUI: document.getElementById('dockUI'),
@@ -68,7 +70,22 @@ initInput({
   dockToggle: () => dockToggle(state, ui, state.planets[0]),
   useGate: () => {},
   hyperspace: () => {},
-  togglePause
+  togglePause,
+  isDebug: () => debugMode,
+  cheatFuel: () => { state.fuel += 50; updateHUD(ui, state); },
+  cheatCargo: () => {
+    state.cargo = Math.min(state.cargoMax, state.cargo + 10);
+    updateHUD(ui, state);
+  },
+  cheatHazard: () => {
+    state.stars.push({ x: state.ship.x + 100, y: state.ship.y, r: 60 });
+  }
+});
+
+initDebug({
+  getState: () => state,
+  isRunning: () => running,
+  isDebug: () => debugMode
 });
 
 const loadingOverlay = document.getElementById('loadingOverlay');
@@ -77,6 +94,10 @@ const startScreen = document.getElementById('startScreen');
 const newGameBtn = document.getElementById('newGameBtn');
 const continueBtn = document.getElementById('continueBtn');
 const startImage = document.getElementById('startImage');
+const debugToggle = document.getElementById('debugToggle');
+debugToggle.addEventListener('change', e => {
+  debugMode = e.target.checked;
+});
 
 let saved = null;
 

--- a/ui/debug.js
+++ b/ui/debug.js
@@ -1,0 +1,40 @@
+export function initDebug(opts){
+  const el = document.createElement('div');
+  el.id = 'debugOverlay';
+  Object.assign(el.style, {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    background: 'rgba(0,0,0,0.7)',
+    color: '#0f0',
+    font: '12px monospace',
+    padding: '4px',
+    display: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(el);
+
+  let last = performance.now();
+  let fps = 0;
+  function loop(now){
+    fps = 1000 / (now - last);
+    last = now;
+    if(el.style.display !== 'none'){
+      const s = opts.getState();
+      if(s){
+        el.innerHTML =
+          `FPS: ${fps.toFixed(1)}<br>` +
+          `Entities: stars ${s.stars.length} planets ${s.planets.length} bullets ${s.bullets.length} particles ${s.particles.length}<br>` +
+          `State: running ${opts.isRunning()} debug ${opts.isDebug()} thrust ${s.ship.thrust} turn ${s.ship.turn}`;
+      }
+    }
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+
+  window.addEventListener('keydown', e => {
+    if(e.code === 'Backquote'){
+      el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add toggleable debug overlay displaying FPS, entity counts, and state flags
- Register debug-only cheat bindings for fuel, cargo, and hazard spawn
- Document available debug commands in README

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adc12bb838832fa34bdfd225dc347f