### PR TITLE
Add market purchase listener and update HUD

### DIFF
--- a/ui/dock.js
+++ b/ui/dock.js
@@ -1,7 +1,30 @@
-import { renderMissionLog } from './hud.js';
+import { renderMissionLog, updateHUD } from './hud.js';
 import { ensureOffersForPlanet } from '../systems/contracts.js';
 import { marketBuy } from '../systems/economy.js';
 import { saveGame } from '../core/save.js';
+
+let marketInit = false;
+const costs = { fuel: 100, ammo: 50, repair: 200 };
+
+function initMarket(ui, state) {
+  if (marketInit) return;
+  ui.dockUI.addEventListener('click', e => {
+    const btn = e.target.closest('[data-buy]');
+    if (!btn) return;
+    const type = btn.dataset.buy;
+    marketBuy(state, type);
+    updateHUD(ui, state);
+    updateBuyButtons(ui, state);
+  });
+  marketInit = true;
+}
+
+function updateBuyButtons(ui, state) {
+  ui.dockUI.querySelectorAll('[data-buy]').forEach(btn => {
+    const cost = costs[btn.dataset.buy] || 0;
+    btn.disabled = state.credits < cost;
+  });
+}
 
 export function renderDock(ui, state){
   if(!state.docked) return;
@@ -14,6 +37,8 @@ export function dock(state, planet, ui){
   state.docked = planet;
   ui.dockUI.style.display = 'flex';
   renderDock(ui, state);
+  initMarket(ui, state);
+  updateBuyButtons(ui, state);
   saveGame(state);
 }
 


### PR DESCRIPTION
## Summary
- Attach delegated click handler on dock UI to process `data-buy` buttons
- Update HUD after purchases and disable buttons when credits are insufficient

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af04d42a2c832faa7c397bcea22a74