### PR TITLE
Add mission log toggle and contract acceptance

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,8 +95,13 @@ const newGameBtn = document.getElementById('newGameBtn');
 const continueBtn = document.getElementById('continueBtn');
 const startImage = document.getElementById('startImage');
 const debugToggle = document.getElementById('debugToggle');
+const missionPill = document.getElementById('missionPill');
+const missionLog = document.getElementById('missionLog');
 debugToggle.addEventListener('change', e => {
   debugMode = e.target.checked;
+});
+missionPill.addEventListener('click', () => {
+  missionLog.style.display = missionLog.style.display === 'block' ? 'none' : 'block';
 });
 
 let saved = null;

--- a/ui/dock.js
+++ b/ui/dock.js
@@ -7,7 +7,18 @@ export function renderDock(ui, state){
   if(!state.docked) return;
   const here = state.docked;
   ensureOffersForPlanet(state, here);
-  ui.missionList.innerHTML = here.offers.map(o => `<div class="item">Deliver ${o.qty} to ${o.to} <span class="badge">$${o.reward}</span></div>`).join('');
+  ui.missionList.innerHTML = here.offers.map(o => `<div class="item" data-id="${o.id}">Deliver ${o.qty} to ${o.to} <span class="badge">$${o.reward}</span></div>`).join('');
+  ui.missionList.querySelectorAll('.item').forEach(el => {
+    el.addEventListener('click', () => {
+      const id = el.dataset.id;
+      const idx = here.offers.findIndex(o => o.id === id);
+      if(idx === -1) return;
+      const mission = here.offers.splice(idx, 1)[0];
+      state.missions.push(mission);
+      renderMissionLog(ui, state);
+      renderDock(ui, state);
+    });
+  });
 }
 
 export function dock(state, planet, ui){


### PR DESCRIPTION
## Summary
- Toggle mission log panel via mission pill
- Allow accepting contracts from the dock UI
- Refresh mission log after accepting a contract

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68af04d4ee30832f80b49e3ddd3218df