### PR TITLE
feat: add interactive world map overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
         <div><span class="swatch" style="background:#9bf"></span> Gate</div>
         <div><span class="swatch" style="background:#9cf"></span> Your Ship</div>
       </div>
+      <button id="mapCloseBtn" class="btn close-btn">Close</button>
     </div>
 
     <div id="touchpad" aria-hidden="true">

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ import { updateWorld, drawWorld } from './world/world.js';
 import { loadAll, getImage } from './core/assets.js';
 import { saveGame, loadGame } from './core/save.js';
 import { initDebug } from './ui/debug.js';
+import { initMap, updateMap } from './ui/map.js';
 
 let state = null;
 let running = false;
@@ -38,6 +39,7 @@ function update(){
 
 function draw(){
   drawWorld(ctx, state);
+  updateMap();
 }
 
 function startGame(loaded){
@@ -87,6 +89,8 @@ initDebug({
   isRunning: () => running,
   isDebug: () => debugMode
 });
+
+initMap({ getState: () => state });
 
 const loadingOverlay = document.getElementById('loadingOverlay');
 const loadingText = document.getElementById('loadingText');

--- a/style.css
+++ b/style.css
@@ -41,8 +41,9 @@
     #mapKey{position:absolute;top:20px;left:20px;padding:8px 10px;border-radius:8px;background:rgba(0,0,0,.55);font-size:14px;line-height:1.4}
     #mapKey div{display:flex;align-items:center;gap:6px;margin-bottom:4px}
     #mapKey div:last-child{margin-bottom:0}
-    #mapKey .swatch{width:12px;height:12px;border-radius:2px;display:inline-block}
-    #startScreen .actions{display:flex;gap:10px;margin-top:10px;flex-wrap:wrap}
+      #mapKey .swatch{width:12px;height:12px;border-radius:2px;display:inline-block}
+      .overlay .close-btn{position:absolute;top:20px;right:20px}
+      #startScreen .actions{display:flex;gap:10px;margin-top:10px;flex-wrap:wrap}
     #startScreen img.start-image{width:100%;height:auto;}
     #leaderboard{margin-top:12px}
     #leaderboard table{width:100%;border-collapse:collapse}

--- a/ui/map.js
+++ b/ui/map.js
@@ -1,0 +1,75 @@
+import { WORLD } from '../core/config.js';
+
+let miniCanvas, miniCtx, bigCanvas, bigCtx, overlay, getState;
+
+function drawMap(ctx, canvas, state){
+  if(!ctx || !state) return;
+  const sx = canvas.width / WORLD.w;
+  const sy = canvas.height / WORLD.h;
+  ctx.clearRect(0,0,canvas.width, canvas.height);
+  // planets
+  ctx.fillStyle = '#8be';
+  for(const p of state.planets){
+    ctx.beginPath();
+    ctx.arc(p.x * sx, p.y * sy, Math.max(2, p.r * sx), 0, Math.PI*2);
+    ctx.fill();
+  }
+  // stars
+  ctx.fillStyle = '#ffd56b';
+  for(const s of state.stars){
+    ctx.beginPath();
+    ctx.arc(s.x * sx, s.y * sy, Math.max(2, s.r * sx), 0, Math.PI*2);
+    ctx.fill();
+  }
+  // black holes if any
+  if(state.blackholes){
+    ctx.fillStyle = '#000';
+    for(const b of state.blackholes){
+      ctx.beginPath();
+      ctx.arc(b.x * sx, b.y * sy, Math.max(2, b.r * sx), 0, Math.PI*2);
+      ctx.fill();
+    }
+  }
+  // ship
+  const ship = state.ship;
+  if(ship){
+    ctx.fillStyle = '#9cf';
+    ctx.beginPath();
+    ctx.arc(ship.x * sx, ship.y * sy, 4, 0, Math.PI*2);
+    ctx.fill();
+  }
+}
+
+export function initMap(opts){
+  getState = opts.getState;
+  miniCanvas = document.getElementById('mini');
+  bigCanvas = document.getElementById('bigmap');
+  overlay = document.getElementById('mapOverlay');
+  if(!miniCanvas || !bigCanvas || !overlay) return;
+  miniCtx = miniCanvas.getContext('2d');
+  bigCtx = bigCanvas.getContext('2d');
+
+  const closeBtn = document.getElementById('mapCloseBtn');
+
+  miniCanvas.addEventListener('click', () => {
+    overlay.classList.remove('hidden');
+    drawMap(bigCtx, bigCanvas, getState());
+  });
+
+  overlay.addEventListener('click', e => {
+    if(e.target === overlay) overlay.classList.add('hidden');
+  });
+
+  if(closeBtn){
+    closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+  }
+}
+
+export function updateMap(){
+  if(!getState) return;
+  const state = getState();
+  drawMap(miniCtx, miniCanvas, state);
+  if(overlay && !overlay.classList.contains('hidden')){
+    drawMap(bigCtx, bigCanvas, state);
+  }
+}


### PR DESCRIPTION
## Summary
- render planets, stars, black holes, and player ship on minimap and full map
- open a full-size map overlay from the minimap and keep both views in sync
- close the map overlay via outside click or new close button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68af04d6d838832f9bd986b4f8d2e937