### PR TITLE
Add upgrade list and purchasing logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,8 @@ const ui = {
   lives: document.getElementById('lives'),
   rep: document.getElementById('rep'),
   missionCount: document.getElementById('missionCount'),
-  missionLogList: document.getElementById('missionLogList')
+  missionLogList: document.getElementById('missionLogList'),
+  upgrades: document.getElementById('upgrades')
 };
 
 function update(){

--- a/systems/economy.js
+++ b/systems/economy.js
@@ -16,11 +16,14 @@ export function upgradeCost(key, level){
 
 export function buyUpgrade(state, key){
   const s = state.ship;
-  const lvl = s[key] || 1;
-  const cost = upgradeCost(key, lvl);
-  if(state.credits < cost) return;
+  const lvl = s[key] || 0;
+  const max = 4;
+  if(lvl >= max) return false;
+  const cost = upgradeCost(key, lvl || 1);
+  if(state.credits < cost) return false;
   state.credits -= cost;
   s[key] = lvl + 1;
+  return true;
 }
 
 export function setHome(state, planet){

--- a/ui/dock.js
+++ b/ui/dock.js
@@ -1,13 +1,34 @@
-import { renderMissionLog } from './hud.js';
+import { updateHUD } from './hud.js';
 import { ensureOffersForPlanet } from '../systems/contracts.js';
-import { marketBuy } from '../systems/economy.js';
+import { marketBuy, buyUpgrade, upgradeCost } from '../systems/economy.js';
 import { saveGame } from '../core/save.js';
+
+export function renderUpgrades(ui, state){
+  const keys = ['engine','gun','hold','shield','radar'];
+  const ship = state.ship;
+  const max = 4;
+  ui.upgrades.innerHTML = keys.map(k => {
+    const lvl = ship[k] || 0;
+    const cost = lvl >= max ? 'MAX' : `$${upgradeCost(k, lvl || 1)}`;
+    const label = k.charAt(0).toUpperCase() + k.slice(1);
+    return `<div class="item" data-upgrade="${k}">${label} Lv ${lvl} <span class="badge">${cost}</span></div>`;
+  }).join('');
+  ui.upgrades.querySelectorAll('[data-upgrade]').forEach(el => {
+    const key = el.dataset.upgrade;
+    el.addEventListener('click', () => {
+      buyUpgrade(state, key);
+      updateHUD(ui, state);
+      renderUpgrades(ui, state);
+    });
+  });
+}
 
 export function renderDock(ui, state){
   if(!state.docked) return;
   const here = state.docked;
   ensureOffersForPlanet(state, here);
   ui.missionList.innerHTML = here.offers.map(o => `<div class="item">Deliver ${o.qty} to ${o.to} <span class="badge">$${o.reward}</span></div>`).join('');
+  renderUpgrades(ui, state);
 }
 
 export function dock(state, planet, ui){


### PR DESCRIPTION
## Summary
- Show available ship upgrades in docking UI with current level and next cost
- Enable buying upgrades with credit checks and level caps
- Track upgrade DOM element in main UI state

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af04d897c0832f90dd881a28b3f4e4