### PR TITLE
Increase star field density

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -8,7 +8,7 @@ export const CFG = {
   hunters: { fireEvery: 90 },
   planets: 8,
   blackholes: 2,
-  stars: 5
+  stars: 200
 };
 
 const num = (v, path) => {


### PR DESCRIPTION
## Summary
- raise CFG.stars to 200 for a denser star backdrop

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "import('./world/gen.js').then(m=>{const s=m.reset(); console.log('stars',s.stars.length);});"`
- `node -e "import('./world/gen.js').then(gen=>{const state = gen.reset(); state.camera={x:0,y:0,w:800,h:600}; import('./world/world.js').then(world=>{let count=0; const ctx={clearRect(){}, fillRect(){count++;}, beginPath(){}, arc(){}, fill(){}, save(){}, translate(){}, rotate(){}, moveTo(){}, lineTo(){}, closePath(){}, restore(){},}; world.drawWorld(ctx,state); console.log('drawn stars',count);});});"`


------
https://chatgpt.com/codex/tasks/task_e_68b08526ab6c832f8fce2dc3429c0e57