### PR TITLE
Bake and use ship/planet textures

### DIFF
--- a/core/assets.js
+++ b/core/assets.js
@@ -1,8 +1,39 @@
-const imageSources = {
-  startScreen: 'StarHauler_Startscreen.png'
-};
+import { CFG } from './config.js';
 
 const images = {};
+
+function bakeShipTexture() {
+  const r = CFG.ship.r;
+  const c = document.createElement('canvas');
+  c.width = c.height = r * 2;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#0f0';
+  ctx.beginPath();
+  ctx.moveTo(r * 2, r);
+  ctx.lineTo(0, r + r / 2);
+  ctx.lineTo(0, r - r / 2);
+  ctx.closePath();
+  ctx.fill();
+  return c;
+}
+
+function bakePlanetTexture() {
+  const r = 40;
+  const c = document.createElement('canvas');
+  c.width = c.height = r * 2;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#0af';
+  ctx.beginPath();
+  ctx.arc(r, r, r, 0, Math.PI * 2);
+  ctx.fill();
+  return c;
+}
+
+const imageSources = {
+  startScreen: 'StarHauler_Startscreen.png',
+  ship: bakeShipTexture,
+  planet: bakePlanetTexture
+};
 
 function loadImage(key, src, onProgress) {
   return new Promise((resolve, reject) => {
@@ -27,7 +58,16 @@ export async function loadAll(progressCallback) {
     loaded++;
     if (progressCallback) progressCallback(loaded / total);
   };
-  const promises = keys.map(key => loadImage(key, imageSources[key], update));
+  const promises = keys.map(key => {
+    const src = imageSources[key];
+    if (typeof src === 'string') {
+      return loadImage(key, src, update);
+    }
+    const img = src();
+    images[key] = img;
+    update();
+    return Promise.resolve(img);
+  });
   await Promise.all(promises);
   return images;
 }

--- a/world/world.js
+++ b/world/world.js
@@ -8,6 +8,7 @@ function isVisible(cam, obj){
 }
 
 import { WORLD } from '../core/config.js';
+import { getImage } from '../core/assets.js';
 
 export function updateWorld(state, dt){
   const cam = state.camera;
@@ -74,24 +75,17 @@ export function drawWorld(ctx, state){
     ctx.fillStyle = '#fff';
     ctx.fillRect(s.x - cam.x, s.y - cam.y, 2, 2);
   }
+  const planetImg = getImage('planet');
   for(const p of state.planets){
     if(!isVisible(cam, p)) continue;
-    ctx.fillStyle = '#0af';
-    ctx.beginPath();
-    ctx.arc(p.x - cam.x, p.y - cam.y, p.r, 0, Math.PI*2);
-    ctx.fill();
+    ctx.drawImage(planetImg, p.x - cam.x - p.r, p.y - cam.y - p.r, p.r*2, p.r*2);
   }
   const ship = state.ship;
+  const shipImg = getImage('ship');
   ctx.save();
   ctx.translate(ship.x - cam.x, ship.y - cam.y);
   ctx.rotate(ship.a);
-  ctx.fillStyle = '#0f0';
-  ctx.beginPath();
-  ctx.moveTo(ship.r, 0);
-  ctx.lineTo(-ship.r, ship.r/2);
-  ctx.lineTo(-ship.r, -ship.r/2);
-  ctx.closePath();
-  ctx.fill();
+  ctx.drawImage(shipImg, -ship.r, -ship.r, ship.r*2, ship.r*2);
   ctx.restore();
   ctx.fillStyle = '#ff0';
   for(const b of state.bullets){


### PR DESCRIPTION
## Summary
- Bake ship and planet textures on off-screen canvases and cache them in the asset loader
- Replace primitive ship and planet drawing with `ctx.drawImage` using baked textures

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check core/assets.js world/world.js`


------
https://chatgpt.com/codex/tasks/task_e_68b086441730832f9673dac954307f9b