### PR TITLE
Clamp ship within world bounds

### DIFF
--- a/world/world.js
+++ b/world/world.js
@@ -23,6 +23,17 @@ export function updateWorld(state, dt){
   }
   s.x += s.vx * dt;
   s.y += s.vy * dt;
+
+  const clampedX = Math.max(s.r, Math.min(WORLD.w - s.r, s.x));
+  if (clampedX !== s.x) {
+    s.x = clampedX;
+    s.vx = 0;
+  }
+  const clampedY = Math.max(s.r, Math.min(WORLD.h - s.r, s.y));
+  if (clampedY !== s.y) {
+    s.y = clampedY;
+    s.vy = 0;
+  }
   s.vx *= 0.99;
   s.vy *= 0.99;
 

--- a/world/world.test.js
+++ b/world/world.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateWorld } from './world.js';
+import { WORLD } from '../core/config.js';
+
+function makeState() {
+  return {
+    camera: { x: 0, y: 0, w: 800, h: 600 },
+    ship: {
+      x: WORLD.w / 2,
+      y: WORLD.h / 2,
+      vx: 0,
+      vy: 0,
+      a: 0,
+      turn: 0,
+      thrust: false,
+      r: 16,
+      centered: true
+    },
+    bullets: [],
+    particles: [],
+    bulletPool: { release() {} },
+    particlePool: { release() {} }
+  };
+}
+
+test('ship clamps to left edge', () => {
+  const state = makeState();
+  state.ship.x = 10;
+  state.ship.vx = -50;
+  updateWorld(state, 1);
+  assert.equal(state.ship.x, state.ship.r);
+  assert.equal(state.ship.vx, 0);
+});
+
+test('ship clamps to top edge', () => {
+  const state = makeState();
+  state.ship.y = 10;
+  state.ship.vy = -50;
+  updateWorld(state, 1);
+  assert.equal(state.ship.y, state.ship.r);
+  assert.equal(state.ship.vy, 0);
+});
+
+test('ship clamps to right edge', () => {
+  const state = makeState();
+  state.ship.x = WORLD.w - 10;
+  state.ship.vx = 50;
+  updateWorld(state, 1);
+  assert.equal(state.ship.x, WORLD.w - state.ship.r);
+  assert.equal(state.ship.vx, 0);
+});
+
+test('ship clamps to bottom edge', () => {
+  const state = makeState();
+  state.ship.y = WORLD.h - 10;
+  state.ship.vy = 50;
+  updateWorld(state, 1);
+  assert.equal(state.ship.y, WORLD.h - state.ship.r);
+  assert.equal(state.ship.vy, 0);
+});


### PR DESCRIPTION
## Summary
- Prevent ship from leaving world area by clamping position and clearing velocity on boundary collision
- Add unit tests ensuring ship stays within map edges

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b08b61ad14832fb1b3783d1d60a025