### PR TITLE
Add asteroid and trader spawning with world updates

### DIFF
--- a/core/assets.js
+++ b/core/assets.js
@@ -29,10 +29,23 @@ function bakePlanetTexture() {
   return c;
 }
 
+function bakeAsteroidTexture(){
+  const r = 20;
+  const c = document.createElement('canvas');
+  c.width = c.height = r * 2;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#888';
+  ctx.beginPath();
+  ctx.arc(r, r, r, 0, Math.PI * 2);
+  ctx.fill();
+  return c;
+}
+
 const imageSources = {
   startScreen: 'StarHauler_Startscreen.png',
   ship: bakeShipTexture,
-  planet: bakePlanetTexture
+  planet: bakePlanetTexture,
+  asteroid: bakeAsteroidTexture
 };
 
 function loadImage(key, src, onProgress) {

--- a/world/gen.js
+++ b/world/gen.js
@@ -27,6 +27,53 @@ export function makeStar(){
   return { x: Math.random()*WORLD.w, y: Math.random()*WORLD.h, r: 60 };
 }
 
+export function makeAsteroid(){
+  const ang = Math.random()*Math.PI*2;
+  const speed = 0.2 + Math.random()*0.8;
+  const r = 10 + Math.random()*20;
+  return {
+    x: Math.random()*WORLD.w,
+    y: Math.random()*WORLD.h,
+    vx: Math.cos(ang)*speed,
+    vy: Math.sin(ang)*speed,
+    r
+  };
+}
+
+export function makeTrader(){
+  const side = Math.floor(Math.random()*4);
+  const m = 80;
+  const pos = [
+    {x:-m, y: Math.random()*WORLD.h},
+    {x:WORLD.w+m, y: Math.random()*WORLD.h},
+    {x:Math.random()*WORLD.w, y:-m},
+    {x:Math.random()*WORLD.w, y:WORLD.h+m}
+  ][side];
+  const ang = Math.random()*Math.PI*2;
+  const speed = 0.5 + Math.random();
+  return {
+    x: pos.x,
+    y: pos.y,
+    vx: Math.cos(ang)*speed,
+    vy: Math.sin(ang)*speed,
+    a: ang,
+    r: 16
+  };
+}
+
+export function spawnAsteroid(state){
+  const a = makeAsteroid();
+  state.asteroids.push(a);
+  return a;
+}
+
+export function spawnTrader(state){
+  const t = makeTrader();
+  if(!state.traders) state.traders = [];
+  state.traders.push(t);
+  return t;
+}
+
 export function reset(seed = Math.random()){
   const state = {
     seed,
@@ -46,6 +93,7 @@ export function reset(seed = Math.random()){
     planets: [],
     blackholes: [],
     pirates: [],
+    traders: [],
     missions: [],
     stars: []
   };
@@ -53,5 +101,7 @@ export function reset(seed = Math.random()){
   for(let i=0;i<CFG.blackholes;i++) state.blackholes.push(makeBlackHole());
   for(let i=0;i<CFG.stars;i++) state.stars.push(makeStar());
   for(let i=0;i<3;i++) state.pirates.push(makePirate());
+  for(let i=0;i<20;i++) state.asteroids.push(makeAsteroid());
+  for(let i=0;i<2;i++) state.traders.push(makeTrader());
   return state;
 }

--- a/world/gen.test.js
+++ b/world/gen.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnAsteroid, spawnTrader } from './gen.js';
+
+function makeState(){
+  return { asteroids: [], traders: [] };
+}
+
+test('spawnAsteroid adds asteroid', () => {
+  const state = makeState();
+  const a = spawnAsteroid(state);
+  assert.equal(state.asteroids.length, 1);
+  assert.ok(typeof a.x === 'number' && typeof a.y === 'number');
+});
+
+test('spawnTrader adds trader', () => {
+  const state = makeState();
+  const t = spawnTrader(state);
+  assert.equal(state.traders.length, 1);
+  assert.ok(typeof t.x === 'number' && typeof t.y === 'number');
+});

--- a/world/world.js
+++ b/world/world.js
@@ -53,6 +53,30 @@ export function updateWorld(state, dt){
   cam.x = Math.max(0, Math.min(WORLD.w - cam.w, cam.x));
   cam.y = Math.max(0, Math.min(WORLD.h - cam.h, cam.y));
 
+  const moveEntities = list => {
+    for(let i=list.length-1;i>=0;i--){
+      const e = list[i];
+      e.x += (e.vx||0) * dt;
+      e.y += (e.vy||0) * dt;
+      const dx = e.x - s.x;
+      const dy = e.y - s.y;
+      if(dx*dx + dy*dy < (e.r + s.r) * (e.r + s.r)){
+        list.splice(i,1);
+        continue;
+      }
+      if(
+        e.x < -e.r || e.x > WORLD.w + e.r ||
+        e.y < -e.r || e.y > WORLD.h + e.r
+      ){
+        list.splice(i,1);
+      }
+    }
+  };
+
+  moveEntities(state.pirates);
+  moveEntities(state.traders);
+  moveEntities(state.asteroids);
+
   for(let i=state.bullets.length-1;i>=0;i--){
     const b = state.bullets[i];
     b.x += b.vx * dt;
@@ -93,6 +117,27 @@ export function drawWorld(ctx, state){
   }
   const ship = state.ship;
   const shipImg = getImage('ship');
+  const asteroidImg = getImage('asteroid') || planetImg;
+  for(const a of state.asteroids){
+    if(!isVisible(cam, a)) continue;
+    ctx.drawImage(asteroidImg, a.x - cam.x - a.r, a.y - cam.y - a.r, a.r*2, a.r*2);
+  }
+  for(const t of state.traders){
+    if(!isVisible(cam, t)) continue;
+    ctx.save();
+    ctx.translate(t.x - cam.x, t.y - cam.y);
+    ctx.rotate(t.a || 0);
+    ctx.drawImage(shipImg, -t.r, -t.r, t.r*2, t.r*2);
+    ctx.restore();
+  }
+  for(const p of state.pirates){
+    if(!isVisible(cam, p)) continue;
+    ctx.save();
+    ctx.translate(p.x - cam.x, p.y - cam.y);
+    ctx.rotate(p.a || 0);
+    ctx.drawImage(shipImg, -p.r, -p.r, p.r*2, p.r*2);
+    ctx.restore();
+  }
   ctx.save();
   ctx.translate(ship.x - cam.x, ship.y - cam.y);
   ctx.rotate(ship.a);

--- a/world/world.test.js
+++ b/world/world.test.js
@@ -20,7 +20,10 @@ function makeState() {
     bullets: [],
     particles: [],
     bulletPool: { release() {} },
-    particlePool: { release() {} }
+    particlePool: { release() {} },
+    pirates: [],
+    traders: [],
+    asteroids: []
   };
 }
 
@@ -58,4 +61,25 @@ test('ship clamps to bottom edge', () => {
   updateWorld(state, 1);
   assert.equal(state.ship.y, WORLD.h - state.ship.r);
   assert.equal(state.ship.vy, 0);
+});
+
+test('asteroids move with velocity', () => {
+  const state = makeState();
+  state.asteroids.push({x:100, y:100, vx:10, vy:0, r:5});
+  updateWorld(state, 1);
+  assert.equal(state.asteroids[0].x, 110);
+});
+
+test('traders move with velocity', () => {
+  const state = makeState();
+  state.traders.push({x:100, y:100, vx:0, vy:5, r:5});
+  updateWorld(state, 1);
+  assert.equal(state.traders[0].y, 105);
+});
+
+test('pirates cleaned when out of bounds', () => {
+  const state = makeState();
+  state.pirates.push({x:-20, y:0, vx:0, vy:0, r:10});
+  updateWorld(state, 1);
+  assert.equal(state.pirates.length, 0);
 });


### PR DESCRIPTION
## Summary
- Add asteroid and trader generators with spawn helpers
- Extend world update & drawing to handle pirates, traders, and asteroids
- Test spawning, movement, and cleanup of new entities

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b0901abca0832fa3cd3f401deebcea