### PR TITLE
Add deterministic RNG to world generation

### DIFF
--- a/entities/npc.js
+++ b/entities/npc.js
@@ -10,44 +10,44 @@ num(CFG.pirateBase?.spawnEvery, 'pirateBase.spawnEvery');
 num(CFG.pirateBase?.fireEvery, 'pirateBase.fireEvery');
 num(CFG.hunters?.fireEvery, 'hunters.fireEvery');
 
-export function makePirate(){
-  const side = Math.floor(Math.random()*4);
+export function makePirate(rand = Math.random){
+  const side = Math.floor(rand()*4);
   const m = 80;
   const pos = [
-    {x:-m, y: Math.random()*WORLD.h},
-    {x:WORLD.w+m, y: Math.random()*WORLD.h},
-    {x:Math.random()*WORLD.w, y:-m},
-    {x:Math.random()*WORLD.w, y:WORLD.h+m}
+    {x:-m, y: rand()*WORLD.h},
+    {x:WORLD.w+m, y: rand()*WORLD.h},
+    {x:rand()*WORLD.w, y:-m},
+    {x:rand()*WORLD.w, y:WORLD.h+m}
   ][side];
   return {x:pos.x, y:pos.y, r:16, vx:0, vy:0, a:0, hp:7, cool:120, boardTimer:90};
 }
 
-export function makePirateBase(){
-  return {x:Math.random()*WORLD.w, y:Math.random()*WORLD.h, r:CFG.pirateBase.r, hp:CFG.pirateBase.hp, spawn:CFG.pirateBase.spawnEvery, cool:CFG.pirateBase.fireEvery};
+export function makePirateBase(rand = Math.random){
+  return {x:rand()*WORLD.w, y:rand()*WORLD.h, r:CFG.pirateBase.r, hp:CFG.pirateBase.hp, spawn:CFG.pirateBase.spawnEvery, cool:CFG.pirateBase.fireEvery};
 }
 
-export function makeHunter(){
-  const side = Math.floor(Math.random()*4);
+export function makeHunter(rand = Math.random){
+  const side = Math.floor(rand()*4);
   const m = 80;
   const pos = [
-    {x:-m, y: Math.random()*WORLD.h},
-    {x:WORLD.w+m, y: Math.random()*WORLD.h},
-    {x:Math.random()*WORLD.w, y:-m},
-    {x:Math.random()*WORLD.w, y:WORLD.h+m}
+    {x:-m, y: rand()*WORLD.h},
+    {x:WORLD.w+m, y: rand()*WORLD.h},
+    {x:rand()*WORLD.w, y:-m},
+    {x:rand()*WORLD.w, y:WORLD.h+m}
   ][side];
   return {x:pos.x, y:pos.y, r:16, vx:0, vy:0, cool:CFG.hunters.fireEvery};
 }
 
-export function makePatrol(){
-  const side = Math.floor(Math.random()*4);
+export function makePatrol(rand = Math.random){
+  const side = Math.floor(rand()*4);
   const m = 80;
   const pos = [
-    {x:-m, y: Math.random()*WORLD.h},
-    {x:WORLD.w+m, y: Math.random()*WORLD.h},
-    {x:Math.random()*WORLD.w, y:-m},
-    {x:Math.random()*WORLD.w, y:WORLD.h+m}
+    {x:-m, y: rand()*WORLD.h},
+    {x:WORLD.w+m, y: rand()*WORLD.h},
+    {x:rand()*WORLD.w, y:-m},
+    {x:rand()*WORLD.w, y:WORLD.h+m}
   ][side];
-  const ang = Math.random()*Math.PI*2;
+  const ang = rand()*Math.PI*2;
   const speed = 1.6;
   return {x:pos.x, y:pos.y, vx:Math.cos(ang)*speed, vy:Math.sin(ang)*speed, a:ang, scan:120, r:14};
 }

--- a/world/gen.js
+++ b/world/gen.js
@@ -3,6 +3,16 @@ import { makePirate } from '../entities/npc.js';
 import { createPool } from '../core/pool.js';
 import { WORLD, CFG } from '../core/config.js';
 
+let rand = Math.random;
+
+function seedRandom(seed) {
+  let s = seed >>> 0;
+  rand = () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
 const num = (v, path) => {
   if (typeof v !== 'number') throw new Error(`CFG.${path} must be a number`);
 };
@@ -16,24 +26,24 @@ num(CFG.blackholes, 'blackholes');
 num(CFG.stars, 'stars');
 
 export function makePlanet(id){
-  return { id, x: Math.random()*WORLD.w, y: Math.random()*WORLD.h, r: 40, offers: [] };
+  return { id, x: rand()*WORLD.w, y: rand()*WORLD.h, r: 40, offers: [] };
 }
 
 export function makeBlackHole(){
-  return { x: Math.random()*WORLD.w, y: Math.random()*WORLD.h, r: 80 };
+  return { x: rand()*WORLD.w, y: rand()*WORLD.h, r: 80 };
 }
 
 export function makeStar(){
-  return { x: Math.random()*WORLD.w, y: Math.random()*WORLD.h, r: 60 };
+  return { x: rand()*WORLD.w, y: rand()*WORLD.h, r: 60 };
 }
 
 export function makeAsteroid(){
-  const ang = Math.random()*Math.PI*2;
-  const speed = 0.2 + Math.random()*0.8;
-  const r = 10 + Math.random()*20;
+  const ang = rand()*Math.PI*2;
+  const speed = 0.2 + rand()*0.8;
+  const r = 10 + rand()*20;
   return {
-    x: Math.random()*WORLD.w,
-    y: Math.random()*WORLD.h,
+    x: rand()*WORLD.w,
+    y: rand()*WORLD.h,
     vx: Math.cos(ang)*speed,
     vy: Math.sin(ang)*speed,
     r
@@ -41,16 +51,16 @@ export function makeAsteroid(){
 }
 
 export function makeTrader(){
-  const side = Math.floor(Math.random()*4);
+  const side = Math.floor(rand()*4);
   const m = 80;
   const pos = [
-    {x:-m, y: Math.random()*WORLD.h},
-    {x:WORLD.w+m, y: Math.random()*WORLD.h},
-    {x:Math.random()*WORLD.w, y:-m},
-    {x:Math.random()*WORLD.w, y:WORLD.h+m}
+    {x:-m, y: rand()*WORLD.h},
+    {x:WORLD.w+m, y: rand()*WORLD.h},
+    {x:rand()*WORLD.w, y:-m},
+    {x:rand()*WORLD.w, y:WORLD.h+m}
   ][side];
-  const ang = Math.random()*Math.PI*2;
-  const speed = 0.5 + Math.random();
+  const ang = rand()*Math.PI*2;
+  const speed = 0.5 + rand();
   return {
     x: pos.x,
     y: pos.y,
@@ -75,6 +85,7 @@ export function spawnTrader(state){
 }
 
 export function reset(seed = Math.random()){
+  seedRandom(seed);
   const state = {
     seed,
     ship: newShip(),
@@ -100,7 +111,7 @@ export function reset(seed = Math.random()){
   for(let i=0;i<CFG.planets;i++) state.planets.push(makePlanet(i));
   for(let i=0;i<CFG.blackholes;i++) state.blackholes.push(makeBlackHole());
   for(let i=0;i<CFG.stars;i++) state.stars.push(makeStar());
-  for(let i=0;i<3;i++) state.pirates.push(makePirate());
+  for(let i=0;i<3;i++) state.pirates.push(makePirate(rand));
   for(let i=0;i<20;i++) state.asteroids.push(makeAsteroid());
   for(let i=0;i<2;i++) state.traders.push(makeTrader());
   return state;

--- a/world/gen.test.js
+++ b/world/gen.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnAsteroid, spawnTrader } from './gen.js';
+import { spawnAsteroid, spawnTrader, reset } from './gen.js';
 
 function makeState(){
   return { asteroids: [], traders: [] };
@@ -18,4 +18,11 @@ test('spawnTrader adds trader', () => {
   const t = spawnTrader(state);
   assert.equal(state.traders.length, 1);
   assert.ok(typeof t.x === 'number' && typeof t.y === 'number');
+});
+
+test('reset with same seed is deterministic', () => {
+  const a = reset(123);
+  const b = reset(123);
+  assert.deepEqual(a.planets, b.planets);
+  assert.deepEqual(a.pirates, b.pirates);
 });


### PR DESCRIPTION
## Summary
- Add simple seeded RNG to `world/gen.js`
- Replace `Math.random` usage in world generation and NPC spawners with seeded RNG
- Seed RNG during `reset` so worlds regenerate consistently
- Test deterministic `reset` behavior

## Testing
- `npm test`
- `node world/gen.test.js`
- `node world/world.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09b7a603c832f88bb068f32a303cb