### PR TITLE
Handle collision damage and game over logic

### DIFF
--- a/world/world.js
+++ b/world/world.js
@@ -53,7 +53,7 @@ export function updateWorld(state, dt){
   cam.x = Math.max(0, Math.min(WORLD.w - cam.w, cam.x));
   cam.y = Math.max(0, Math.min(WORLD.h - cam.h, cam.y));
 
-  const moveEntities = list => {
+  const moveEntities = (list, type) => {
     for(let i=list.length-1;i>=0;i--){
       const e = list[i];
       e.x += (e.vx||0) * dt;
@@ -61,6 +61,17 @@ export function updateWorld(state, dt){
       const dx = e.x - s.x;
       const dy = e.y - s.y;
       if(dx*dx + dy*dy < (e.r + s.r) * (e.r + s.r)){
+        if(type === 'pirate' || type === 'asteroid'){
+          const dmg = e.damage || 10;
+          s.hull -= dmg;
+          if(s.hull <= 0){
+            s.lives--;
+            if(s.lives <= 0) state.gameOver = true;
+            s.hull = s.hullMax;
+          }
+        } else if(type === 'trader'){
+          state.gameOver = true;
+        }
         list.splice(i,1);
         continue;
       }
@@ -73,9 +84,9 @@ export function updateWorld(state, dt){
     }
   };
 
-  moveEntities(state.pirates);
-  moveEntities(state.traders);
-  moveEntities(state.asteroids);
+  moveEntities(state.pirates, 'pirate');
+  moveEntities(state.traders, 'trader');
+  moveEntities(state.asteroids, 'asteroid');
 
   for(let i=state.bullets.length-1;i>=0;i--){
     const b = state.bullets[i];

--- a/world/world.test.js
+++ b/world/world.test.js
@@ -15,7 +15,10 @@ function makeState() {
       turn: 0,
       thrust: false,
       r: 16,
-      centered: true
+      centered: true,
+      hull: 100,
+      hullMax: 100,
+      lives: 3
     },
     bullets: [],
     particles: [],
@@ -23,7 +26,8 @@ function makeState() {
     particlePool: { release() {} },
     pirates: [],
     traders: [],
-    asteroids: []
+    asteroids: [],
+    gameOver: false
   };
 }
 
@@ -82,4 +86,22 @@ test('pirates cleaned when out of bounds', () => {
   state.pirates.push({x:-20, y:0, vx:0, vy:0, r:10});
   updateWorld(state, 1);
   assert.equal(state.pirates.length, 0);
+});
+
+test('pirate collision damages hull and removes pirate', () => {
+  const state = makeState();
+  const pirate = {x: state.ship.x, y: state.ship.y, r: 10, damage: 10};
+  state.pirates.push(pirate);
+  updateWorld(state, 1);
+  assert.equal(state.pirates.length, 0);
+  assert.equal(state.ship.hull, 90);
+});
+
+test('trader collision triggers game over and removes trader', () => {
+  const state = makeState();
+  const trader = {x: state.ship.x, y: state.ship.y, r: 10};
+  state.traders.push(trader);
+  updateWorld(state, 1);
+  assert.equal(state.traders.length, 0);
+  assert.equal(state.gameOver, true);
 });


### PR DESCRIPTION
## Summary
- Apply hull damage or trigger game over when the ship collides with pirates, traders, or asteroids
- Update ship state before removing colliding entities
- Add tests for hull damage and collision cleanup

## Testing
- `node world/world.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a34bb9d4832fbe5a683f2016d78e