### PR TITLE
Persist ship resources and missions in save data

### DIFF
--- a/core/save.js
+++ b/core/save.js
@@ -5,6 +5,13 @@ export function saveGame(state) {
   const data = {
     seed: state.seed,
     credits: state.credits,
+    fuel: state.fuel,
+    ammo: state.ammo,
+    cargo: state.cargo,
+    ship: {
+      x: state.ship?.x,
+      y: state.ship?.y
+    },
     upgrades: {
       engine: state.ship?.engine,
       hold: state.ship?.hold,
@@ -13,7 +20,8 @@ export function saveGame(state) {
       radar: state.ship?.radar
     },
     reputation: state.reputation || 0,
-    discovered: state.discovered || []
+    discovered: state.discovered || [],
+    missions: state.missions || []
   };
   try {
     localStorage.setItem(SAVE_KEY, JSON.stringify(data));
@@ -26,7 +34,14 @@ export function loadGame() {
   try {
     const raw = localStorage.getItem(SAVE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const data = JSON.parse(raw);
+    // Backward compatibility for saves without new fields
+    if (!data.missions) data.missions = [];
+    if (!data.ship) data.ship = {};
+    if (typeof data.fuel !== 'number') data.fuel = undefined;
+    if (typeof data.ammo !== 'number') data.ammo = undefined;
+    if (typeof data.cargo !== 'number') data.cargo = undefined;
+    return data;
   } catch (err) {
     console.warn('Failed to load game', err);
     return null;

--- a/main.js
+++ b/main.js
@@ -70,6 +70,14 @@ function startGame(loaded){
     state.credits = loaded.credits;
     state.reputation = loaded.reputation || 0;
     state.discovered = loaded.discovered || [];
+    if (typeof loaded.fuel === 'number') state.fuel = loaded.fuel;
+    if (typeof loaded.ammo === 'number') state.ammo = loaded.ammo;
+    if (typeof loaded.cargo === 'number') state.cargo = loaded.cargo;
+    if (loaded.ship) {
+      if (typeof loaded.ship.x === 'number') state.ship.x = loaded.ship.x;
+      if (typeof loaded.ship.y === 'number') state.ship.y = loaded.ship.y;
+    }
+    state.missions = loaded.missions || [];
     Object.assign(state.ship, loaded.upgrades || {});
   } else {
     state = reset();


### PR DESCRIPTION
## Summary
- Save additional state including fuel, ammo, cargo, ship position, and active missions
- Restore these values when loading a game, with sensible defaults for older saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a4c1a21c832f88e802d6cea37fec